### PR TITLE
改正目录组件搜寻标题逻辑，避免错误识别页面其他标题导致无法高亮

### DIFF
--- a/pages/archive/[para].vue
+++ b/pages/archive/[para].vue
@@ -31,7 +31,8 @@
           </MarkdownRender>
 
           <!-- 目录 -->
-          <MarkdownTOC class="hidden md:block ml-2 sticky top-20 self-start" :items="tocItems">
+          <MarkdownTOC class="hidden md:block ml-2 sticky top-20 self-start" :items="tocItems"
+            :markdown-render-ref="markdownRender">
           </MarkdownTOC>
         </div>
 


### PR DESCRIPTION
之前给组件进行了无障碍优化，给目录组件的h2标签添加了ID，结果后面发现目录组件会把这个也看做目录标题的一部分，导致无法正常高亮目录标题.现在限制搜寻标题的范围在markdownRender内，防止造成奇奇怪怪的问题

同时优化了搜索逻辑，避免不必要的反复查找