### PR TITLE
修正link的tag文本前景色不会一直为白色的问题

### DIFF
--- a/pages/links.vue
+++ b/pages/links.vue
@@ -61,7 +61,7 @@
                             </h3>
                             <div class="flex flex-wrap gap-1">
                                 <div v-for="(tag, index) in link.tags" :key="index"
-                                    class="px-2 py-1 rounded text-xs font-medium whitespace-nowrap"
+                                    class="px-2 py-1 rounded text-xs font-medium whitespace-nowrap text-white"
                                     :style="{ backgroundColor: getRandomColor(tag) }">
                                     {{ tag }}
                                 </div>


### PR DESCRIPTION
相关链接页中tag文本前景色应该一直为白色，而不是跟随系统自动切换颜色