### PR TITLE
统一页面标题管理，使用 usePageTitle 并增强 SEO/SSR 标题格式化

### DIFF
--- a/composables/useBotMeta.ts
+++ b/composables/useBotMeta.ts
@@ -93,6 +93,7 @@ export interface UseBotMetaOptions {
     type?: "website" | "article";
     siteName?: string;
     locale?: string;
+    titleFormatter?: (title: string) => string;
 }
 
 export async function useBotMeta(
@@ -134,7 +135,10 @@ export async function useBotMeta(
 
     if (!payload) return;
 
-    const title = payload.data?.title || payload.title || "";
+    const rawTitle = payload.data?.title || payload.title || "";
+    const title = options.titleFormatter
+        ? options.titleFormatter(rawTitle)
+        : rawTitle;
     const description = buildExcerpt(
         payload.data?.body || payload.data?.content || "",
     );

--- a/composables/usePageTitle.ts
+++ b/composables/usePageTitle.ts
@@ -1,12 +1,34 @@
+import { useI18n } from "vue-i18n";
+
 export const usePageTitle = () => {
     const titleKey = useState<string>("page_title_key", () => "");
+    const titleRaw = useState<string>("page_title_raw", () => "");
+    const titleSuffixKey = useState<string>("page_title_suffix_key", () => "");
 
-    const setPageTitle = (key: string) => {
+    const { t } = useI18n();
+
+    const setPageTitle = (key: string, raw?: string, suffixKey?: string) => {
         titleKey.value = key;
+        titleRaw.value = raw || "";
+        titleSuffixKey.value = suffixKey || "";
     };
+
+    const displayTitle = computed(() => {
+        if (titleRaw.value) return titleRaw.value;
+        if (titleKey.value) return t(titleKey.value);
+        return "";
+    });
+
+    const displaySuffix = computed(() => {
+        if (titleSuffixKey.value) return ` ${t(titleSuffixKey.value)}`;
+        return "";
+    });
 
     return {
         titleKey,
+        titleRaw,
+        displayTitle,
+        displaySuffix,
         setPageTitle,
     };
 };

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -361,3 +361,50 @@ onUnmounted(() => {
 ```
 
 外层添加了 `lg:hidden`，因此该区域在大屏幕上不会出现，左右两列的功能不受影响。
+
+---
+
+## 页面标题管理
+
+全站页面标题（`<title>`）由 `usePageTitle` 统一管理，禁止在页面组件中通过 `useHead` 直接硬编码 `title`。
+
+### 1. 开发普通页面
+
+在普通页面（如时间线、成员页）中，使用 `setPageTitle` 注册当前页面的标题名。
+
+```ts
+const { setPageTitle } = usePageTitle();
+
+// 建议：直接传入 i18n key，由组合式函数内部处理多语言响应
+setPageTitle("pages.timeline.title");
+```
+
+### 2. 开发带有特定版块后缀的页面
+
+如果你正在开发属于 **Archive（归档）** 或 **Wiki** 范畴的动态页面，需要传入版块后缀的 i18n key。
+
+```ts
+// 参数 1: i18n key (若不使用则填空字符串)
+// 参数 2: 动态拉取的 Raw string (如文章标题)
+// 参数 3: 版块后缀的 i18n key (如 "nav.archive")
+setPageTitle("", content.title, "nav.archive");
+```
+
+### 3. 处理搜索引擎爬虫 (SSR)
+
+由于爬虫不会执行 JS 修改标题，必须在页面 `script setup` 顶层配合 `useBotMeta` 使用。为了保证 SEO 效果与用户看到的标题一致，**必须**手动提供 `titleFormatter`：
+
+```ts
+await useBotMeta(() => `API_URL`, {
+    // ... 其他配置
+    titleFormatter: (title) =>
+        `${title} - ${t("meta.fullName")} ${t("nav.archive")}`,
+});
+```
+
+### 4. 标题组装规范
+
+`layouts/default.vue` 会根据配置自动按照以下规则拼装标题，**开发时无需手动拼接字符串**：
+
+- **普通页面**：`标题 - 协会全称` (如：`时间线 - 江西财经大学网络安全协会`)
+- **带版块页面**：`标题 - 协会全称 [空格] 版块名` (如：`2026新春 - 江西财经大学网络安全协会 归档`)

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -17,9 +17,15 @@ import WikiTree from "@/components/sidebars/WikiTree.vue";
 
 const { t } = useI18n();
 const { notificationRef } = useNotification();
-const { titleKey } = usePageTitle();
+const { titleKey, displayTitle, displaySuffix } = usePageTitle();
 
-const hasPageTitle = computed(() => !!titleKey.value);
+useHead(() => ({
+    title: displayTitle.value
+        ? `${displayTitle.value} - ${t("meta.fullName")}${displaySuffix.value}`
+        : t("pages.home.meta.title"),
+}));
+
+const hasPageTitle = computed(() => !!titleKey.value || !!displayTitle.value);
 
 const {
     leftCards,

--- a/pages/about/index.vue
+++ b/pages/about/index.vue
@@ -24,7 +24,6 @@ const quotes = [
 ];
 
 useHead(() => ({
-    title: t("pages.about.index.meta.title"),
     meta: [
         {
             name: "description",

--- a/pages/about/leaders.vue
+++ b/pages/about/leaders.vue
@@ -28,7 +28,6 @@ const { setPageTitle } = usePageTitle();
 setPageTitle("pages.about.leaders.title");
 
 useHead(() => ({
-    title: t("pages.about.leaders.meta.title"),
     meta: [
         {
             name: "description",

--- a/pages/archive/[para].vue
+++ b/pages/archive/[para].vue
@@ -132,7 +132,13 @@ const { t, locale } = useI18n();
 await useBotMeta(
     () =>
         `/v1/contents/by-path/archive/${route.params.para}?i18n=${getApiLocale(locale.value)}`,
-    { schema: "Article", type: "article", locale: locale.value },
+    {
+        schema: "Article",
+        type: "article",
+        locale: locale.value,
+        titleFormatter: (title) =>
+            `${title} - ${t("meta.fullName")} ${t("nav.archive")}`,
+    },
 );
 
 const { setHasContent, clearRightSidebar } = useRightSidebar();
@@ -147,13 +153,8 @@ const currentSlug = computed(() => String(para.value ?? ""));
 const { prev: archivePrev, next: archiveNext } =
     useArchivePrevNext(currentSlug);
 
-const pageTitle = computed(() => {
-    const title = archive.value?.data?.title || archive.value?.title;
-    return title
-        ? `${title} - 江西财经大学网络安全协会
-  `
-        : "加载中...";
-});
+const { setPageTitle } = usePageTitle();
+
 function handleTocUpdate(items: TocItem[]) {
     tocItems.value = items;
     setHasContent(items.length > 0);
@@ -166,11 +167,19 @@ function handleTocUpdate(items: TocItem[]) {
         },
     });
 }
-useHead({
-    title: pageTitle,
-});
-const { setPageTitle } = usePageTitle();
-setPageTitle("");
+
+watch(
+    () => archive.value,
+    (newArchive) => {
+        if (newArchive) {
+            const title = newArchive.data?.title || newArchive.title;
+            if (title) {
+                setPageTitle("", title, "nav.archive");
+            }
+        }
+    },
+    { immediate: true },
+);
 
 const currentContentLang = ref(getApiLocale(locale.value));
 

--- a/pages/archive/index.vue
+++ b/pages/archive/index.vue
@@ -63,10 +63,9 @@ import { usePageTitle } from "@/composables/usePageTitle";
 const { t } = useI18n();
 const { setPageTitle } = usePageTitle();
 
-setPageTitle("pages.archive.title");
+setPageTitle("pages.archive.title", "", "nav.archive");
 
 useHead(() => ({
-    title: t("pages.archive.meta.title"),
     meta: [
         { name: "description", content: t("pages.archive.meta.description") },
         { name: "keywords", content: t("pages.archive.meta.keywords") },
@@ -92,8 +91,8 @@ const loadArchives = async (page: number = 1) => {
     );
     if (archives.value) {
         if (meta.value) {
-            totalPages.value = meta.value.total_pages;
-            currentPage.value = meta.value.current_page;
+            totalPages.value = meta.value.total_pages || 1;
+            currentPage.value = meta.value.current_page || 1;
         }
     } else {
         console.error("加载失败", error.value);

--- a/pages/ctf-event.vue
+++ b/pages/ctf-event.vue
@@ -265,7 +265,9 @@
                                     :style="desktopCalendarSpacerStyle(week)"
                                 />
                                 <button
-                                    v-if="week.hiddenCounts[dayIndex] > 0"
+                                    v-if="
+                                        (week.hiddenCounts?.[dayIndex] || 0) > 0
+                                    "
                                     type="button"
                                     class="text-xs font-medium text-(--md-sys-color-primary) underline-offset-4 hover:underline"
                                     @click="openListForDay(cell.date)"
@@ -274,9 +276,10 @@
                                         t(
                                             "pages.ctf.events.summary.moreEvents",
                                             {
-                                                count: week.hiddenCounts[
-                                                    dayIndex
-                                                ],
+                                                count:
+                                                    week.hiddenCounts?.[
+                                                        dayIndex
+                                                    ] || 0,
                                             },
                                         )
                                     }}
@@ -446,7 +449,7 @@
                                             >
                                                 <AnzuButton
                                                     variant="filled"
-                                                    class="h-9! min-w-[6rem]! shrink-0 whitespace-nowrap px-4! text-sm!"
+                                                    class="h-9! min-w-24! shrink-0 whitespace-nowrap px-4! text-sm!"
                                                     :href="event.比赛链接"
                                                     target="_blank"
                                                 >
@@ -573,7 +576,7 @@
                                 >
                                     <AnzuButton
                                         variant="filled"
-                                        class="h-10! min-w-[6rem]! shrink-0 whitespace-nowrap px-4!"
+                                        class="h-10! min-w-24! shrink-0 whitespace-nowrap px-4!"
                                         :href="event.比赛链接"
                                         target="_blank"
                                     >
@@ -751,7 +754,7 @@
                         <div class="mt-4 flex items-center justify-end gap-2">
                             <AnzuButton
                                 variant="filled"
-                                class="h-10! min-w-[6rem]! shrink-0 whitespace-nowrap px-4!"
+                                class="h-10! min-w-24! shrink-0 whitespace-nowrap px-4!"
                                 :href="event.比赛链接"
                                 target="_blank"
                             >
@@ -882,7 +885,6 @@ const monthCursor = ref(
 
 setPageTitle("pages.ctf.title");
 useHead(() => ({
-    title: t("pages.ctf.meta.title"),
     meta: [{ name: "description", content: t("pages.ctf.meta.description") }],
 }));
 
@@ -940,8 +942,13 @@ const normalizeDomesticDateText = (value?: string) => {
         /^(\d{4})[年/-](\d{1,2})[月/-](\d{1,2})日?\s+(\d{1,2}):(\d{2})(?::(\d{2}))?$/,
     );
     if (!match) return trimmed;
-    const [, year, month, day, hour, minute, second] = match;
-    return `${year}-${pad(month)}-${pad(day)} ${pad(hour)}:${minute}${second ? `:${second}` : ""}`;
+    const year = match[1]!;
+    const month = match[2]!;
+    const day = match[3]!;
+    const hour = match[4]!;
+    const minute = match[5]!;
+    const second = match[6];
+    return `${year}-${pad(month)}-${pad(day)} ${pad(hour)}:${minute}${second ? `:${pad(second)}` : ""}`;
 };
 
 const normalizeDateInput = (value: string) =>
@@ -1442,7 +1449,7 @@ const normalizeDomesticEvents = (payload: unknown): RawCTFEvent[] => {
                 比赛状态: event.status?.trim(),
                 比赛详情: event.readmore?.trim(),
                 地区: "domestic" as EventRegion,
-            };
+            } as RawCTFEvent;
         })
         .filter((event): event is RawCTFEvent => event !== null);
 };

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -127,7 +127,6 @@ import type { Archive } from "~/types/archives";
 const { t } = useI18n();
 
 useHead(() => ({
-    title: t("pages.home.meta.title"),
     meta: [{ name: "description", content: t("pages.home.meta.description") }],
 }));
 

--- a/pages/links.vue
+++ b/pages/links.vue
@@ -77,7 +77,6 @@ const { setPageTitle } = usePageTitle();
 setPageTitle("pages.links.title");
 
 useHead(() => ({
-    title: t("pages.links.meta.title"),
     meta: [
         { name: "description", content: t("pages.links.meta.description") },
         { name: "keywords", content: t("pages.links.meta.keywords") },

--- a/pages/privacy.vue
+++ b/pages/privacy.vue
@@ -7,7 +7,6 @@ const { setPageTitle } = usePageTitle();
 setPageTitle("pages.privacy.title");
 
 useHead(() => ({
-    title: t("pages.privacy.meta.title"),
     meta: [
         {
             name: "description",

--- a/pages/wiki/[...slug].vue
+++ b/pages/wiki/[...slug].vue
@@ -229,7 +229,13 @@ await useBotMeta(
         if (!segs.length) return null;
         return `/v1/contents/by-path/wiki/${segs.join("/")}?i18n=${getApiLocale(locale.value)}`;
     },
-    { schema: "TechArticle", type: "article", locale: locale.value },
+    {
+        schema: "TechArticle",
+        type: "article",
+        locale: locale.value,
+        titleFormatter: (title) =>
+            `${title} - ${t("meta.fullName")} ${t("nav.wiki")}`,
+    },
 );
 
 const slug = computed(() => {
@@ -430,11 +436,17 @@ const showError = computed(
     () => !isPageLoading.value && !!currentPageError.value,
 );
 
-useHead(() => ({
-    title: content.value?.data?.title
-        ? `${pageTitle.value} - ${t("meta.fullName")}Wiki`
-        : t("pages.wiki.meta.title"),
-}));
+watch(
+    [() => content.value, () => treeNode.value, () => locale.value],
+    () => {
+        const title =
+            content.value?.data?.title ||
+            treeNode.value?.title ||
+            t("pages.wiki.title");
+        setSitePageTitle("", title, "nav.wiki");
+    },
+    { immediate: true },
+);
 
 function handleTocUpdate(items: TocItem[]) {
     tocItems.value = items;
@@ -497,12 +509,10 @@ const fetchContent = async () => {
 
 const updateLayout = () => {
     if (isFolderView.value) {
-        // Re-enable page title for folder views
-        setSitePageTitle("pages.wiki.title");
+        setSitePageTitle("", pageTitle.value, "nav.wiki");
     } else {
         registerWikiToc();
-        // Hide Main Page Title when reading content (User Request)
-        setSitePageTitle("");
+        setSitePageTitle("", pageTitle.value, "nav.wiki");
     }
 };
 

--- a/pages/wiki/index.vue
+++ b/pages/wiki/index.vue
@@ -69,7 +69,7 @@ const { setPageTitle } = usePageTitle();
 const { t } = useI18n();
 const router = useRouter();
 
-setPageTitle("pages.wiki.title");
+setPageTitle("pages.wiki.title", "", "nav.wiki");
 
 const { data, get, loading, error } = useApi<WikiTreeNode>();
 
@@ -86,7 +86,6 @@ onMounted(() => {
 });
 
 useHead(() => ({
-    title: t("pages.wiki.meta.title"),
     meta: [{ name: "description", content: t("pages.wiki.meta.description") }],
 }));
 </script>


### PR DESCRIPTION
该 PR 引入了一套统一且灵活的页面标题管理系统，将所有逻辑集中到新的 `usePageTitle` 组合式函数中，并更新了所有页面以使用该系统。它还通过支持为爬虫自定义标题格式来改进 SSR/SEO 兼容性，并重构了相关代码以提高一致性和可维护性。此外，还对活动页面和归档页面进行了次要改进和错误修复。

**页面标题管理统一化**

*   引入了 `usePageTitle` 组合式函数，提供响应式状态和辅助方法（`setPageTitle`、`displayTitle`、`displaySuffix`），用于以统一且支持 i18n 的方式设置和显示页面标题。所有页面现在都使用该系统，而不是直接通过 `useHead` 设置标题。（`composables/usePageTitle.ts` [[1]](diffhunk://#diff-cd699979da8a29c6ed75381eedef7d0cca8d7ab652b610f74682f5afc15e8aa4R1-R31)、`layouts/default.vue` [[2]](diffhunk://#diff-433a9abd4ca70520f69fc064c160bb093918ce26dda6087a8bbfdbe2895d1944L20-R28)、文档 [[3]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782R364-R410)）
*   更新了所有页面（about、archive、wiki、links、privacy、CTF event、home），移除了 `useHead` 中直接设置 `<title>` 的代码，改为调用 `setPageTitle` 并传入合适的键名或原始标题。（`pages/about/index.vue` [[1]](diffhunk://#diff-415a4f9d069e89569a0d39755af0e91f3fbd009f63216a9c598786f21481665cL27)、`pages/about/leaders.vue` [[2]](diffhunk://#diff-fa09a4089cd2ea91d5393540cad4d2c203e1cfe6e4e6b796dc77138d602397d8L31)、`pages/archive/[para].vue` [pages/archive/[para].vueL135-R141](diffhunk://#diff-18deabb66aefd1be4e5b12bf1561c702f39b5297983acd2b5ae98b54cb537dd7L135-R141) [pages/archive/[para].vueL150-R157](diffhunk://#diff-18deabb66aefd1be4e5b12bf1561c702f39b5297983acd2b5ae98b54cb537dd7L150-R157) [pages/archive/[para].vueL169-R182](diffhunk://#diff-18deabb66aefd1be4e5b12bf1561c702f39b5297983acd2b5ae98b54cb537dd7L169-R182)、`pages/archive/index.vue` [[3]](diffhunk://#diff-b2dafac3e422776ca8cd3a033680998fd065cc83a8b3d85e945d6fbbe2071f6cL66-L69) [[4]](diffhunk://#diff-b2dafac3e422776ca8cd3a033680998fd065cc83a8b3d85e945d6fbbe2071f6cL95-R95)、`pages/ctf-event.vue` [[5]](diffhunk://#diff-c156812174f5e94bb73e8abfe75f774ea0927f265f3b18d43abb7c9a32ad893dL885)、`pages/index.vue` [[6]](diffhunk://#diff-02281a80fab758cb4e8e8359b222a8a5afeaa9d5a7ba858f15d852f1f8969ecfL130)、`pages/links.vue` [[7]](diffhunk://#diff-366b963cc4a191a1c7196eeb6af18e14dbb7d6624fa1d0aa578c285f2a402e66L80)、`pages/privacy.vue` [[8]](diffhunk://#diff-82ab98bb82c033db41a7be115cf472c67f0b8269bc803e84f3e6ac6c0185dafbL10)、`pages/wiki/index.vue` [[9]](diffhunk://#diff-34d6b2977b026798c27b6fd4ddfafecf06f206a40e7351bc942c3b15ffd18063L72-R72) [[10]](diffhunk://#diff-34d6b2977b026798c27b6fd4ddfafecf06f206a40e7351bc942c3b15ffd18063L89)、`pages/wiki/[...slug].vue` [pages/wiki/[...slug].vueL433-R449](diffhunk://#diff-56b5dddede33e62c57e548bca4b42ed06a84174055d363cff37397f33ed830bdL433-R449) [pages/wiki/[...slug].vueL500-R515](diffhunk://#diff-56b5dddede33e62c57e548bca4b42ed06a84174055d363cff37397f33ed830bdL500-R515)）

**SEO 和 SSR 标题格式化**

*   增强了 `useBotMeta`，接受 `titleFormatter` 选项，允许为爬虫/SSR 自定义标题格式，以确保与用户看到的 SEO 标题一致。此功能已在动态归档页面和 Wiki 页面中使用。（`composables/useBotMeta.ts` [[1]](diffhunk://#diff-2b3a99ccb6fe63b16dcfc886587a4c44eb4c4f5920d858cbc7ce9b5458b771cfR96) [[2]](diffhunk://#diff-2b3a99ccb6fe63b16dcfc886587a4c44eb4c4f5920d858cbc7ce9b5458b771cfL137-R141)、`pages/archive/[para].vue` [pages/archive/[para].vueL135-R141](diffhunk://#diff-18deabb66aefd1be4e5b12bf1561c702f39b5297983acd2b5ae98b54cb537dd7L135-R141)、`pages/wiki/[...slug].vue` [pages/wiki/[...slug].vueL232-R238](diffhunk://#diff-56b5dddede33e62c57e548bca4b42ed06a84174055d363cff37397f33ed830bdL232-R238)）
*   添加了文档，解释了新的标题管理工作流以及 SSR 相关要求。

**错误修复和次要改进**

*   修复了活动页面和归档页面中可能出现的未定义错误，改进了回退逻辑，例如在分页信息缺失时默认使用第 1 页，并修正了日期格式。（`pages/archive/index.vue` [[1]](diffhunk://#diff-b2dafac3e422776ca8cd3a033680998fd065cc83a8b3d85e945d6fbbe2071f6cL95-R95)、`pages/ctf-event.vue` [[2]](diffhunk://#diff-c156812174f5e94bb73e8abfe75f774ea0927f265f3b18d43abb7c9a32ad893dL268-R270) [[3]](diffhunk://#diff-c156812174f5e94bb73e8abfe75f774ea0927f265f3b18d43abb7c9a32ad893dL277-R282) [[4]](diffhunk://#diff-c156812174f5e94bb73e8abfe75f774ea0927f265f3b18d43abb7c9a32ad893dL449-R452) [[5]](diffhunk://#diff-c156812174f5e94bb73e8abfe75f774ea0927f265f3b18d43abb7c9a32ad893dL576-R579) [[6]](diffhunk://#diff-c156812174f5e94bb73e8abfe75f774ea0927f265f3b18d43abb7c9a32ad893dL754-R757) [[7]](diffhunk://#diff-c156812174f5e94bb73e8abfe75f774ea0927f265f3b18d43abb7c9a32ad893dL943-R951) [[8]](diffhunk://#diff-c156812174f5e94bb73e8abfe75f774ea0927f265f3b18d43abb7c9a32ad893dL1445-R1452)）
*   在 CTF 活动页面中统一了按钮宽度，使 UI 更一致。（`pages/ctf-event.vue` [[1]](diffhunk://#diff-c156812174f5e94bb73e8abfe75f774ea0927f265f3b18d43abb7c9a32ad893dL449-R452) [[2]](diffhunk://#diff-c156812174f5e94bb73e8abfe75f774ea0927f265f3b18d43abb7c9a32ad893dL576-R579) [[3]](diffhunk://#diff-c156812174f5e94bb73e8abfe75f774ea0927f265f3b18d43abb7c9a32ad893dL754-R757)）

**代码一致性与重构**

*   确保所有动态和静态页面使用相同的标题组装逻辑，`layouts/default.vue` 负责组合标题、站点名称和章节后缀。（`layouts/default.vue` [[1]](diffhunk://#diff-433a9abd4ca70520f69fc064c160bb093918ce26dda6087a8bbfdbe2895d1944L20-R28)、文档 [[2]](diffhunk://#diff-140eef3ba41bdcf401d507408084181f2c0ac627532b61e0f7906ea7cc926782R364-R410)）
*   将分散且不一致的标题逻辑替换为集中化、可维护的 `usePageTitle` 调用。（涉及多个文件，见上）

**文档**

*   在架构文档中添加了详细章节，概述了新的页面标题管理方法、使用模式以及 SSR/SEO 注意事项。