### PR TITLE
style(markdown): 优化竖版图片在横屏设备上的宽度自适应

### DIFF
--- a/assets/css/markdown.css
+++ b/assets/css/markdown.css
@@ -298,12 +298,16 @@
 }
 
 .markdown-wrapper img {
+    --md-img-max-height: 70vh;
     border-radius: var(--border-radius-base);
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
     max-width: 100%;
+    max-height: var(--md-img-max-height);
+    width: auto;
     height: auto;
     display: block;
     margin: 16px auto;
+    object-fit: contain;
 }
 
 .markdown-wrapper code,


### PR DESCRIPTION
通过设置最大高度（`70vh`）、使用 `object-fit: contain` 并确保图片在 `.markdown-wrapper img` 内响应式缩放，改进了 `assets/css/markdown.css` 中的 markdown 图片显示。