### PR TITLE
添加招生计划数据源，并统一页面元数据处理

### DIFF
--- a/composables/useNavLinks.ts
+++ b/composables/useNavLinks.ts
@@ -7,6 +7,7 @@ import {
     ClockIcon,
     BookOpenIcon,
     TrophyIcon,
+    AcademicCapIcon,
 } from "@heroicons/vue/24/outline";
 export interface NavChildLink {
     path: string;
@@ -76,6 +77,12 @@ export const useNavLinks = (): NavLink[] => {
             label: "nav.ctf",
             alwaysInMore: true,
             icon: TrophyIcon,
+        },
+        {
+            path: "/volunteer",
+            label: "nav.volunteer",
+            alwaysInMore: true,
+            icon: AcademicCapIcon,
         },
     ];
 };

--- a/composables/usePageMeta.ts
+++ b/composables/usePageMeta.ts
@@ -1,0 +1,102 @@
+import { usePageTitle } from "./usePageTitle";
+
+export interface PageMetaOptions {
+    titleKey?: string;
+    titleOverride?: string;
+    descriptionKey: string;
+    suffixKey?: string;
+    keywords?: string;
+    canonicalPath?: string;
+    schema?: Record<string, unknown> | null;
+    noIndex?: boolean;
+}
+
+export function usePageMeta(options: PageMetaOptions) {
+    const { t, locale, locales } = useI18n();
+    const config = useRuntimeConfig();
+    const route = useRoute();
+    const { setPageTitle } = usePageTitle();
+
+    const siteUrl = ((config.public.siteUrl as string) || "").replace(
+        /\/+$/,
+        "",
+    );
+    const canonicalPath = options.canonicalPath ?? route.path;
+    const url = `${siteUrl}${canonicalPath}`;
+    const ogLocale = computed(() => {
+        const current = (locales.value as { code: string; iso: string }[]).find(
+            (l) => l.code === locale.value,
+        );
+        return (current?.iso ?? "zh-CN").replace("-", "_");
+    });
+
+    if (options.titleKey) {
+        setPageTitle(options.titleKey, undefined, options.suffixKey);
+    }
+
+    const pageTitle = computed(() => {
+        if (options.titleOverride) return options.titleOverride;
+        if (options.titleKey) return t(options.titleKey);
+        return t("pages.home.meta.title");
+    });
+    const ogTitle = computed(
+        () => `${pageTitle.value} - ${t("meta.fullName")}`,
+    );
+    const description = computed(() => t(options.descriptionKey));
+
+    useSeoMeta({
+        ogType: "website",
+        ogTitle,
+        ogDescription: description,
+        ogUrl: () => url,
+        ogSiteName: () => t("meta.fullName"),
+        ogLocale,
+        twitterCard: "summary",
+        twitterTitle: ogTitle,
+        twitterDescription: description,
+    });
+
+    useHead(() => {
+        const headConfig: Record<string, unknown> = {
+            meta: [
+                { name: "description", content: description.value },
+                {
+                    name: "robots",
+                    content: options.noIndex
+                        ? "noindex, follow"
+                        : "index, follow",
+                },
+            ],
+            link: [{ rel: "canonical", href: url }],
+        };
+
+        if (options.keywords) {
+            (headConfig.meta as Record<string, unknown>[]).push({
+                name: "keywords",
+                content: options.keywords,
+            });
+        }
+
+        if (options.schema !== null) {
+            const baseSchema: Record<string, unknown> = {
+                "@context": "https://schema.org",
+                "@type": "WebPage",
+                name: ogTitle.value,
+                description: description.value,
+                url,
+            };
+
+            if (options.schema) {
+                const merged = { ...baseSchema, ...options.schema };
+                headConfig.script = [
+                    {
+                        type: "application/ld+json",
+                        innerHTML: JSON.stringify(merged),
+                    },
+                ];
+            }
+        }
+
+        return headConfig;
+    });
+}

--- a/composables/usePageMeta.ts
+++ b/composables/usePageMeta.ts
@@ -31,7 +31,9 @@ export function usePageMeta(options: PageMetaOptions) {
     });
 
     if (options.titleKey) {
-        setPageTitle(options.titleKey, undefined, options.suffixKey);
+        setPageTitle(options.titleKey, options.titleOverride, options.suffixKey);
+    } else {
+        setPageTitle("", options.titleOverride, options.suffixKey);
     }
 
     const pageTitle = computed(() => {
@@ -86,15 +88,15 @@ export function usePageMeta(options: PageMetaOptions) {
                 url,
             };
 
-            if (options.schema) {
-                const merged = { ...baseSchema, ...options.schema };
-                headConfig.script = [
-                    {
-                        type: "application/ld+json",
-                        innerHTML: JSON.stringify(merged),
-                    },
-                ];
-            }
+            const merged = options.schema
+                ? { ...baseSchema, ...options.schema }
+                : baseSchema;
+            headConfig.script = [
+                {
+                    type: "application/ld+json",
+                    innerHTML: JSON.stringify(merged),
+                },
+            ];
         }
 
         return headConfig;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -364,47 +364,78 @@ onUnmounted(() => {
 
 ---
 
-## 页面标题管理
+## 页面 SEO
 
-全站页面标题（`<title>`）由 `usePageTitle` 统一管理，禁止在页面组件中通过 `useHead` 直接硬编码 `title`。
+全站 SEO 元数据（`<title>`、OG、Twitter、canonical、JSON-LD 等）由两套组合式函数分管，**禁止在页面组件中直接调用 `useHead` / `useSeoMeta` / `setPageTitle` 拼凑标签**。
 
-### 1. 开发普通页面
+| 组合式函数 | 适用场景 | 覆盖范围 |
+|-----------|---------|---------|
+| `usePageMeta` | 所有静态页面 | `<title>` + OG + Twitter + canonical + keywords + robots + JSON-LD |
+| `useBotMeta` | CMS 动态页面（`archive/[para]`、`wiki/[...slug]`） | 同上，但仅在服务端对爬虫 UA 渲染 |
 
-在普通页面（如时间线、成员页）中，使用 `setPageTitle` 注册当前页面的标题名。
+两者互斥，一个页面只调用其中一种。
 
-```ts
-const { setPageTitle } = usePageTitle();
+---
 
-// 建议：直接传入 i18n key，由组合式函数内部处理多语言响应
-setPageTitle("pages.timeline.title");
-```
+### `usePageMeta`：静态页面
 
-### 2. 开发带有特定版块后缀的页面
-
-如果你正在开发属于 **Archive（归档）** 或 **Wiki** 范畴的动态页面，需要传入版块后缀的 i18n key。
+一行调用覆盖全部 SEO 标签，内部自动处理标题注册、OG/Twitter 社交分享、结构化数据等：
 
 ```ts
-// 参数 1: i18n key (若不使用则填空字符串)
-// 参数 2: 动态拉取的 Raw string (如文章标题)
-// 参数 3: 版块后缀的 i18n key (如 "nav.archive")
-setPageTitle("", content.title, "nav.archive");
-```
+import { usePageMeta } from "@/composables/usePageMeta";
 
-### 3. 处理搜索引擎爬虫 (SSR)
-
-由于爬虫不会执行 JS 修改标题，必须在页面 `script setup` 顶层配合 `useBotMeta` 使用。为了保证 SEO 效果与用户看到的标题一致，**必须**手动提供 `titleFormatter`：
-
-```ts
-await useBotMeta(() => `API_URL`, {
-    // ... 其他配置
-    titleFormatter: (title) =>
-        `${title} - ${t("meta.fullName")} ${t("nav.archive")}`,
+usePageMeta({
+    titleKey: "pages.volunteer.title",            // i18n key，用于 <title> + og:title
+    descriptionKey: "pages.volunteer.meta.description",
+    keywords: "江财,志愿填报,录取分数",               // 可选
+    canonicalPath: "/volunteer",                    // 可选，默认取 route.path
+    suffixKey: "nav.archive",                       // 可选，版块后缀
+    schema: { "@type": "WebApplication", ... },     // 可选，自定义 JSON-LD；传 null 跳过
+    noIndex: false,                                  // 可选，设为 true 输出 noindex
 });
 ```
 
-### 4. 标题组装规范
+- `titleKey` 可省略（如首页），此时沿用 layout 的默认标题
+- 无需手动拼接 ` - 江西财经大学网络安全协会`，layout 自动完成
+- `ogLocale` 自动跟随当前语言（zh → zh_CN, en → en_US, ja → ja_JP, ko → ko_KR）
+- 所有标签在 SSR 阶段即注入 HTML，爬虫无需执行 JS 即可获取完整元数据
 
-`layouts/default.vue` 会根据配置自动按照以下规则拼装标题，**开发时无需手动拼接字符串**：
+**首页特殊处理**：首页不设置 `titleKey`，仅传入 `descriptionKey` + `canonicalPath`，标题沿用 `pages.home.meta.title`（即全站默认标题）。
 
-- **普通页面**：`标题 - 协会全称` (如：`时间线 - 江西财经大学网络安全协会`)
-- **带版块页面**：`标题 - 协会全称 [空格] 版块名` (如：`2026新春 - 江西财经大学网络安全协会 归档`)
+---
+
+### `useBotMeta`：CMS 动态页面
+
+仅用于 `archive/[para].vue` 和 `wiki/[...slug].vue`——这两个页面的标题和内容来自 CMS API，在服务端渲染时需要额外请求数据才能生成 SEO 标签。
+
+```ts
+await useBotMeta(
+    () => `/v1/contents/${route.params.para}`,
+    {
+        schema: "Article",
+        type: "article",
+        titleFormatter: (title) =>
+            `${title} - ${t("meta.fullName")} ${t("nav.archive")}`,
+    },
+);
+```
+
+- 仅在服务端、且 User-Agent 匹配已知爬虫（Googlebot、Baiduspider 等 29 种）时执行
+- 从 CMS API 拉取文章标题与正文，提取摘要作为 description，生成 JSON-LD Article schema
+- 非爬虫请求直接跳过，由客户端渲染后再设置标题
+
+---
+
+### `<title>` 组装流程
+
+无论使用 `usePageMeta` 还是 `useBotMeta`，最终的 `<title>` 标签由 `layouts/default.vue` 统一组装：
+
+```
+{pageTitle} - {meta.fullName}{suffix}
+```
+
+- **普通页面**：`时间线 - 江西财经大学网络安全协会`
+- **带版块页面**：`2026新春 - 江西财经大学网络安全协会 归档`
+- **首页**（无 pageTitle）：`江西财经大学网络安全协会 - 共筑网络安全 坚守网络防线`
+
+开发时**无需在页面中手动拼接标题字符串**。

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -12,6 +12,7 @@
         "links": "Useful Links",
         "timeline": "Timeline",
         "ctf": "CTF Events",
+        "volunteer": "Score Lookup",
         "aboutChildren": {
             "index": "Guild Overview",
             "leaders": "Past Leaders",
@@ -88,7 +89,109 @@
                 }
             }
         },
+        "volunteer": {
+            "title": "Score Lookup",
+            "meta": {
+                "title": "Score Lookup - Cybersecurity Guild of JXUFE",
+                "description": "Look up historical admission scores by province and major for JXUFE, providing reference for college applications."
+            },
+            "loading": "Loading data...",
+            "error": "Failed to load configuration. Please try again later.",
+            "fetchError": "Failed to fetch score data",
+            "empty": "No data found",
+            "emptyHint": "No admission data for the selected filters. Try adjusting your selection.",
+            "selectHint": "Select year and province, then click Search",
+            "summary": "Total {count} records",
+            "scoreHint": "Your score: {score}",
+            "rankingHint": "Your rank: #{ranking}",
+            "filters": {
+                "year": "Year",
+                "province": "Province",
+                "category": "Category",
+                "batch": "Batch",
+                "planType": "Plan Type",
+                "yourScore": "Your Score",
+                "yourRanking": "Your Rank",
+                "query": "Search",
+                "reset": "Reset",
+                "dataSource": "Data Source"
+            },
+            "placeholder": {
+                "year": "Select year",
+                "province": "Select province",
+                "category": "Select category (optional)",
+                "planType": "Select plan type (optional)",
+                "score": "Enter score (optional)",
+                "ranking": "Enter rank (optional)"
+            },
+            "dataSource": {
+                "zsjy": "Admissions",
+                "ranking": "Guild Extended",
+                "plan": "Admission Plan",
+                "zsjyDescription": "Data sourced from JXUFE's official undergraduate admissions website, containing only max/min admission scores without ranking information.",
+                "rankingDescription": "Provincial ranking data (max/min score ranks) supplemented by the Cybersecurity Guild. Ranking data is for reference only.",
+                "planDescription": "Data sourced from JXUFE's official undergraduate admissions website, showing the planned enrollment numbers for each major by province."
+            },
+            "table": {
+                "major": "Major",
+                "maxScore": "Max Score",
+                "minScore": "Min Score",
+                "maxRanking": "Max Rank",
+                "minRanking": "Min Rank",
+                "match": "Match",
+                "category": "Category",
+                "batch": "Batch",
+                "notes": "Notes",
+                "planCount": "Plan Count",
+                "planType": "Plan Type",
+                "majorCode": "Major Code"
+            },
+            "status": {
+                "safe": "Safe",
+                "match": "Match",
+                "reach": "Reach",
+                "far": "Far"
+            },
+            "sourceAlert": {
+                "title": "Data Source"
+            }
+        },
         "privacy": {
+            "volunteer": {
+                "title": "Score Lookup",
+                "meta": {
+                    "title": "Score Lookup - Cybersecurity Guild of JXUFE",
+                    "description": "Look up historical admission scores by province and major for JXUFE, providing reference for college applications."
+                },
+                "loading": "Loading data...",
+                "error": "Failed to load configuration. Please try again later.",
+                "fetchError": "Failed to fetch score data",
+                "empty": "No data found",
+                "emptyHint": "No admission data for the selected filters. Try adjusting your selection.",
+                "selectHint": "Select year and province, then click Search",
+                "summary": "Total {count} records",
+                "filters": {
+                    "year": "Year",
+                    "province": "Province",
+                    "category": "Category",
+                    "batch": "Batch",
+                    "query": "Search",
+                    "reset": "Reset"
+                },
+                "placeholder": {
+                    "year": "Select year",
+                    "province": "Select province",
+                    "category": "Select category (optional)"
+                },
+                "table": {
+                    "major": "Major",
+                    "maxScore": "Max Score",
+                    "minScore": "Min Score",
+                    "category": "Category",
+                    "batch": "Batch",
+                    "notes": "Notes"
+                }
+            },
             "title": "Privacy Policy",
             "meta": {
                 "title": "Privacy Policy - Cybersecurity Guild of JXUFE",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -157,41 +157,6 @@
             }
         },
         "privacy": {
-            "volunteer": {
-                "title": "Score Lookup",
-                "meta": {
-                    "title": "Score Lookup - Cybersecurity Guild of JXUFE",
-                    "description": "Look up historical admission scores by province and major for JXUFE, providing reference for college applications."
-                },
-                "loading": "Loading data...",
-                "error": "Failed to load configuration. Please try again later.",
-                "fetchError": "Failed to fetch score data",
-                "empty": "No data found",
-                "emptyHint": "No admission data for the selected filters. Try adjusting your selection.",
-                "selectHint": "Select year and province, then click Search",
-                "summary": "Total {count} records",
-                "filters": {
-                    "year": "Year",
-                    "province": "Province",
-                    "category": "Category",
-                    "batch": "Batch",
-                    "query": "Search",
-                    "reset": "Reset"
-                },
-                "placeholder": {
-                    "year": "Select year",
-                    "province": "Select province",
-                    "category": "Select category (optional)"
-                },
-                "table": {
-                    "major": "Major",
-                    "maxScore": "Max Score",
-                    "minScore": "Min Score",
-                    "category": "Category",
-                    "batch": "Batch",
-                    "notes": "Notes"
-                }
-            },
             "title": "Privacy Policy",
             "meta": {
                 "title": "Privacy Policy - Cybersecurity Guild of JXUFE",

--- a/i18n/locales/ja.json
+++ b/i18n/locales/ja.json
@@ -12,6 +12,7 @@
         "links": "関連リンク",
         "timeline": "タイムライン",
         "ctf": "CTF イベント",
+        "volunteer": "スコア検索",
         "aboutChildren": {
             "index": "ギルド概要",
             "leaders": "歴代責任者",
@@ -28,7 +29,134 @@
                 "description": "江西財経大学サイバーセキュリティギルドの発展の歴史と重要なマイルストーンを記録します。"
             }
         },
+        "volunteer": {
+            "title": "スコア検索",
+            "meta": {
+                "title": "スコア検索 - 江西財経大学サイバーセキュリティギルド",
+                "description": "江西財経大学の年度別・省別・専攻別の入学スコアを検索し、志望校選びの参考にできます。"
+            },
+            "loading": "データを読み込んでいます...",
+            "error": "設定データの読み込みに失敗しました。後でもう一度お試しください。",
+            "fetchError": "データの取得に失敗しました",
+            "empty": "データが見つかりません",
+            "emptyHint": "この条件では入学データがありません。条件を変更してお試しください。",
+            "selectHint": "年度と省を選択してから検索ボタンを押してください",
+            "summary": "全 {count} 件",
+            "scoreHint": "あなたの点数：{score} 点",
+            "rankingHint": "あなたの順位：第 {ranking} 位",
+            "filters": {
+                "year": "年度",
+                "province": "省",
+                "category": "科目",
+                "batch": "入学区分",
+                "yourScore": "あなたの点数",
+                "yourRanking": "あなたの順位",
+                "query": "検索",
+                "reset": "リセット",
+                "dataSource": "データソース"
+            },
+            "placeholder": {
+                "year": "年度を選択",
+                "province": "省を選択",
+                "category": "科目を選択（任意）",
+                "score": "点数を入力（任意）",
+                "ranking": "順位を入力（任意）"
+            },
+            "dataSource": {
+                "zsjy": "入試情報",
+                "ranking": "ギルド拡張",
+                "zsjyDescription": "江西財経大学の公式入試情報サイトの公開データに基づき、専攻別の最高点・最低点のみを表示します（順位情報なし）。",
+                "rankingDescription": "サイバーセキュリティギルドが省順位データ（最高点順位・最低点順位）を独自に補完したものです。順位は参考値としてご利用ください。"
+            },
+            "table": {
+                "major": "専攻名",
+                "maxScore": "最高点",
+                "minScore": "最低点",
+                "maxRanking": "最高順位",
+                "minRanking": "最低順位",
+                "match": "マッチ",
+                "category": "科目",
+                "batch": "入学区分",
+                "notes": "備考"
+            },
+            "status": {
+                "safe": "安全",
+                "match": "適合",
+                "reach": "挑戦可",
+                "far": "距離大"
+            },
+            "sourceAlert": {
+                "title": "データソースについて"
+            }
+        },
         "privacy": {
+            "volunteer": {
+                "title": "スコア検索",
+                "meta": {
+                    "title": "スコア検索 - 江西財経大学サイバーセキュリティギルド",
+                    "description": "江西財経大学の年度別・省別・専攻別の入学スコアを検索し、志望校選びの参考にできます。"
+                },
+                "loading": "データを読み込んでいます...",
+                "error": "設定データの読み込みに失敗しました。後でもう一度お試しください。",
+                "fetchError": "データの取得に失敗しました",
+                "empty": "データが見つかりません",
+                "emptyHint": "この条件では入学データがありません。条件を変更してお試しください。",
+                "selectHint": "年度と省を選択してから検索ボタンを押してください",
+                "summary": "全 {count} 件",
+                "scoreHint": "あなたの点数：{score} 点",
+                "rankingHint": "あなたの順位：第 {ranking} 位",
+                "filters": {
+                    "year": "年度",
+                    "province": "省",
+                    "category": "科目",
+                    "batch": "入学区分",
+                    "planType": "計画種別",
+                    "yourScore": "あなたの点数",
+                    "yourRanking": "あなたの順位",
+                    "query": "検索",
+                    "reset": "リセット",
+                    "dataSource": "データソース"
+                },
+                "placeholder": {
+                    "year": "年度を選択",
+                    "province": "省を選択",
+                    "category": "科目を選択（任意）",
+                    "planType": "計画種別を選択（任意）",
+                    "score": "点数を入力（任意）",
+                    "ranking": "順位を入力（任意）"
+                },
+                "dataSource": {
+                    "zsjy": "入学情報",
+                    "ranking": "ギルド拡張",
+                    "plan": "募集計画",
+                    "zsjyDescription": "江西財経大学の公式入試情報サイトからの公開データで、専攻別の最高点と最低点のみが含まれ、順位情報はありません。",
+                    "rankingDescription": "サイバーセキュリティギルドが省順位情報（最高点順位と最低点順位）を補完しました。順位データは参考値です。",
+                    "planDescription": "江西財経大学の公式入試情報サイトからの公開データで、各省の専攻別の計画募集人数を表示します。"
+                },
+                "table": {
+                    "major": "専攻名",
+                    "maxScore": "最高点",
+                    "minScore": "最低点",
+                    "maxRanking": "最高順位",
+                    "minRanking": "最低順位",
+                    "match": "適合",
+                    "category": "科目",
+                    "batch": "入学区分",
+                    "notes": "備考",
+                    "planCount": "募集人数",
+                    "planType": "計画種別",
+                    "majorCode": "専攻コード"
+                },
+                "status": {
+                    "safe": "安定",
+                    "match": "適合",
+                    "reach": "挑戦可",
+                    "far": "差大"
+                },
+                "sourceAlert": {
+                    "title": "データソースについて"
+                }
+            },
             "title": "プライバシーポリシー",
             "meta": {
                 "title": "プライバシーポリシー - 江西財経大学サイバーセキュリティギルド",

--- a/i18n/locales/ja.json
+++ b/i18n/locales/ja.json
@@ -49,6 +49,7 @@
                 "province": "省",
                 "category": "科目",
                 "batch": "入学区分",
+                "planType": "計画種別",
                 "yourScore": "あなたの点数",
                 "yourRanking": "あなたの順位",
                 "query": "検索",
@@ -59,14 +60,17 @@
                 "year": "年度を選択",
                 "province": "省を選択",
                 "category": "科目を選択（任意）",
+                "planType": "計画種別を選択（任意）",
                 "score": "点数を入力（任意）",
                 "ranking": "順位を入力（任意）"
             },
             "dataSource": {
                 "zsjy": "入試情報",
                 "ranking": "ギルド拡張",
+                "plan": "募集計画",
                 "zsjyDescription": "江西財経大学の公式入試情報サイトの公開データに基づき、専攻別の最高点・最低点のみを表示します（順位情報なし）。",
-                "rankingDescription": "サイバーセキュリティギルドが省順位データ（最高点順位・最低点順位）を独自に補完したものです。順位は参考値としてご利用ください。"
+                "rankingDescription": "サイバーセキュリティギルドが省順位データ（最高点順位・最低点順位）を独自に補完したものです。順位は参考値としてご利用ください。",
+                "planDescription": "江西財経大学の公式入試情報サイトからの公開データで、各省の専攻別の計画募集人数を表示します。"
             },
             "table": {
                 "major": "専攻名",
@@ -77,7 +81,10 @@
                 "match": "マッチ",
                 "category": "科目",
                 "batch": "入学区分",
-                "notes": "備考"
+                "notes": "備考",
+                "planCount": "募集人数",
+                "planType": "計画種別",
+                "majorCode": "専攻コード"
             },
             "status": {
                 "safe": "安全",
@@ -90,73 +97,6 @@
             }
         },
         "privacy": {
-            "volunteer": {
-                "title": "スコア検索",
-                "meta": {
-                    "title": "スコア検索 - 江西財経大学サイバーセキュリティギルド",
-                    "description": "江西財経大学の年度別・省別・専攻別の入学スコアを検索し、志望校選びの参考にできます。"
-                },
-                "loading": "データを読み込んでいます...",
-                "error": "設定データの読み込みに失敗しました。後でもう一度お試しください。",
-                "fetchError": "データの取得に失敗しました",
-                "empty": "データが見つかりません",
-                "emptyHint": "この条件では入学データがありません。条件を変更してお試しください。",
-                "selectHint": "年度と省を選択してから検索ボタンを押してください",
-                "summary": "全 {count} 件",
-                "scoreHint": "あなたの点数：{score} 点",
-                "rankingHint": "あなたの順位：第 {ranking} 位",
-                "filters": {
-                    "year": "年度",
-                    "province": "省",
-                    "category": "科目",
-                    "batch": "入学区分",
-                    "planType": "計画種別",
-                    "yourScore": "あなたの点数",
-                    "yourRanking": "あなたの順位",
-                    "query": "検索",
-                    "reset": "リセット",
-                    "dataSource": "データソース"
-                },
-                "placeholder": {
-                    "year": "年度を選択",
-                    "province": "省を選択",
-                    "category": "科目を選択（任意）",
-                    "planType": "計画種別を選択（任意）",
-                    "score": "点数を入力（任意）",
-                    "ranking": "順位を入力（任意）"
-                },
-                "dataSource": {
-                    "zsjy": "入学情報",
-                    "ranking": "ギルド拡張",
-                    "plan": "募集計画",
-                    "zsjyDescription": "江西財経大学の公式入試情報サイトからの公開データで、専攻別の最高点と最低点のみが含まれ、順位情報はありません。",
-                    "rankingDescription": "サイバーセキュリティギルドが省順位情報（最高点順位と最低点順位）を補完しました。順位データは参考値です。",
-                    "planDescription": "江西財経大学の公式入試情報サイトからの公開データで、各省の専攻別の計画募集人数を表示します。"
-                },
-                "table": {
-                    "major": "専攻名",
-                    "maxScore": "最高点",
-                    "minScore": "最低点",
-                    "maxRanking": "最高順位",
-                    "minRanking": "最低順位",
-                    "match": "適合",
-                    "category": "科目",
-                    "batch": "入学区分",
-                    "notes": "備考",
-                    "planCount": "募集人数",
-                    "planType": "計画種別",
-                    "majorCode": "専攻コード"
-                },
-                "status": {
-                    "safe": "安定",
-                    "match": "適合",
-                    "reach": "挑戦可",
-                    "far": "差大"
-                },
-                "sourceAlert": {
-                    "title": "データソースについて"
-                }
-            },
             "title": "プライバシーポリシー",
             "meta": {
                 "title": "プライバシーポリシー - 江西財経大学サイバーセキュリティギルド",

--- a/i18n/locales/ko.json
+++ b/i18n/locales/ko.json
@@ -49,6 +49,7 @@
                 "province": "지역",
                 "category": "계열",
                 "batch": "전형",
+                "planType": "계획유형",
                 "yourScore": "내 점수",
                 "yourRanking": "내 순위",
                 "query": "검색",
@@ -59,14 +60,17 @@
                 "year": "연도 선택",
                 "province": "지역 선택",
                 "category": "계열 선택 (선택사항)",
+                "planType": "계획유형 선택 (선택사항)",
                 "score": "점수 입력 (선택사항)",
                 "ranking": "순위 입력 (선택사항)"
             },
             "dataSource": {
                 "zsjy": "입학처",
                 "ranking": "길드 확장",
+                "plan": "모집계획",
                 "zsjyDescription": "장시 재경대학교 공식 입학처 웹사이트의 공개 데이터를 기반으로 하며, 전공별 최고점/최저점만 제공합니다 (순위 정보 없음).",
-                "rankingDescription": "사이버보안 길드가 자체적으로 성(省) 순위 데이터(최고점 순위/최저점 순위)를 보완했습니다. 순위는 참고용으로만 사용하세요."
+                "rankingDescription": "사이버보안 길드가 자체적으로 성(省) 순위 데이터(최고점 순위/최저점 순위)를 보완했습니다. 순위는 참고용으로만 사용하세요.",
+                "planDescription": "장시 재경대학교 공식 입학정보 사이트의 공개 데이터로, 각 지역별 전공 계획 모집 인원을 표시합니다."
             },
             "table": {
                 "major": "전공명",
@@ -77,7 +81,10 @@
                 "match": "매칭",
                 "category": "계열",
                 "batch": "전형",
-                "notes": "비고"
+                "notes": "비고",
+                "planCount": "모집인원",
+                "planType": "계획유형",
+                "majorCode": "전공코드"
             },
             "status": {
                 "safe": "안정",
@@ -90,73 +97,6 @@
             }
         },
         "privacy": {
-            "volunteer": {
-                "title": "점수 조회",
-                "meta": {
-                    "title": "점수 조회 - 장시 재경대학교 사이버보안 길드",
-                    "description": "장시 재경대학교의 연도별, 지역별, 전공별 입학 점수를 조회하여 진학 지원에 참고하세요."
-                },
-                "loading": "데이터를 불러오는 중...",
-                "error": "설정 데이터를 불러오지 못했습니다. 나중에 다시 시도해 주세요.",
-                "fetchError": "데이터 조회에 실패했습니다",
-                "empty": "데이터가 없습니다",
-                "emptyHint": "선택한 조건에 해당하는 입학 데이터가 없습니다. 조건을 변경해 보세요.",
-                "selectHint": "연도와 지역을 선택한 후 검색을 클릭하세요",
-                "summary": "총 {count}건",
-                "scoreHint": "내 점수: {score}점",
-                "rankingHint": "내 순위: 제 {ranking}위",
-                "filters": {
-                    "year": "연도",
-                    "province": "지역",
-                    "category": "계열",
-                    "batch": "전형",
-                    "planType": "계획유형",
-                    "yourScore": "내 점수",
-                    "yourRanking": "내 순위",
-                    "query": "검색",
-                    "reset": "초기화",
-                    "dataSource": "데이터 출처"
-                },
-                "placeholder": {
-                    "year": "연도 선택",
-                    "province": "지역 선택",
-                    "category": "계열 선택 (선택사항)",
-                    "planType": "계획유형 선택 (선택사항)",
-                    "score": "점수 입력 (선택사항)",
-                    "ranking": "순위 입력 (선택사항)"
-                },
-                "dataSource": {
-                    "zsjy": "입학정보",
-                    "ranking": "길드 확장",
-                    "plan": "모집계획",
-                    "zsjyDescription": "장시 재경대학교 공식 입학정보 사이트의 공개 데이터로, 전공별 최고점과 최저점만 포함되어 있으며 순위 정보는 없습니다.",
-                    "rankingDescription": "사이버보안 길드가 지역별 순위 정보(최고점 순위 및 최저점 순위)를 보완했습니다. 순위 데이터는 참고용입니다.",
-                    "planDescription": "장시 재경대학교 공식 입학정보 사이트의 공개 데이터로, 각 지역별 전공 계획 모집 인원을 표시합니다."
-                },
-                "table": {
-                    "major": "전공명",
-                    "maxScore": "최고점",
-                    "minScore": "최저점",
-                    "maxRanking": "최고순위",
-                    "minRanking": "최저순위",
-                    "match": "적합",
-                    "category": "계열",
-                    "batch": "전형",
-                    "notes": "비고",
-                    "planCount": "모집인원",
-                    "planType": "계획유형",
-                    "majorCode": "전공코드"
-                },
-                "status": {
-                    "safe": "안정",
-                    "match": "적합",
-                    "reach": "도전가능",
-                    "far": "차이큼"
-                },
-                "sourceAlert": {
-                    "title": "데이터 출처 안내"
-                }
-            },
             "title": "개인정보 처리방침",
             "meta": {
                 "title": "개인정보 처리방침 - 장시 재경대학교 사이버보안 길드",

--- a/i18n/locales/ko.json
+++ b/i18n/locales/ko.json
@@ -12,6 +12,7 @@
         "links": "유용한 링크",
         "timeline": "타임라인",
         "ctf": "CTF 대회",
+        "volunteer": "점수 조회",
         "aboutChildren": {
             "index": "길드 개요",
             "leaders": "역대 리더",
@@ -28,7 +29,134 @@
                 "description": "장시 재경대학교 사이버보안 길드의 발전 역사와 주요 이정표를 기록합니다."
             }
         },
+        "volunteer": {
+            "title": "점수 조회",
+            "meta": {
+                "title": "점수 조회 - 장시 재경대학교 사이버보안 길드",
+                "description": "장시 재경대학교의 연도별, 지역별, 전공별 입학 점수를 조회하여 진학 지원에 참고하세요."
+            },
+            "loading": "데이터를 불러오는 중...",
+            "error": "설정 데이터를 불러오지 못했습니다. 나중에 다시 시도해 주세요.",
+            "fetchError": "데이터 조회에 실패했습니다",
+            "empty": "데이터가 없습니다",
+            "emptyHint": "선택한 조건에 해당하는 입학 데이터가 없습니다. 조건을 변경해 보세요.",
+            "selectHint": "연도와 지역을 선택한 후 검색을 클릭하세요",
+            "summary": "총 {count}건",
+            "scoreHint": "내 점수: {score}점",
+            "rankingHint": "내 순위: {ranking}위",
+            "filters": {
+                "year": "연도",
+                "province": "지역",
+                "category": "계열",
+                "batch": "전형",
+                "yourScore": "내 점수",
+                "yourRanking": "내 순위",
+                "query": "검색",
+                "reset": "초기화",
+                "dataSource": "데이터 출처"
+            },
+            "placeholder": {
+                "year": "연도 선택",
+                "province": "지역 선택",
+                "category": "계열 선택 (선택사항)",
+                "score": "점수 입력 (선택사항)",
+                "ranking": "순위 입력 (선택사항)"
+            },
+            "dataSource": {
+                "zsjy": "입학처",
+                "ranking": "길드 확장",
+                "zsjyDescription": "장시 재경대학교 공식 입학처 웹사이트의 공개 데이터를 기반으로 하며, 전공별 최고점/최저점만 제공합니다 (순위 정보 없음).",
+                "rankingDescription": "사이버보안 길드가 자체적으로 성(省) 순위 데이터(최고점 순위/최저점 순위)를 보완했습니다. 순위는 참고용으로만 사용하세요."
+            },
+            "table": {
+                "major": "전공명",
+                "maxScore": "최고점",
+                "minScore": "최저점",
+                "maxRanking": "최고 순위",
+                "minRanking": "최저 순위",
+                "match": "매칭",
+                "category": "계열",
+                "batch": "전형",
+                "notes": "비고"
+            },
+            "status": {
+                "safe": "안정",
+                "match": "적합",
+                "reach": "도전",
+                "far": "거리 있음"
+            },
+            "sourceAlert": {
+                "title": "데이터 출처 안내"
+            }
+        },
         "privacy": {
+            "volunteer": {
+                "title": "점수 조회",
+                "meta": {
+                    "title": "점수 조회 - 장시 재경대학교 사이버보안 길드",
+                    "description": "장시 재경대학교의 연도별, 지역별, 전공별 입학 점수를 조회하여 진학 지원에 참고하세요."
+                },
+                "loading": "데이터를 불러오는 중...",
+                "error": "설정 데이터를 불러오지 못했습니다. 나중에 다시 시도해 주세요.",
+                "fetchError": "데이터 조회에 실패했습니다",
+                "empty": "데이터가 없습니다",
+                "emptyHint": "선택한 조건에 해당하는 입학 데이터가 없습니다. 조건을 변경해 보세요.",
+                "selectHint": "연도와 지역을 선택한 후 검색을 클릭하세요",
+                "summary": "총 {count}건",
+                "scoreHint": "내 점수: {score}점",
+                "rankingHint": "내 순위: 제 {ranking}위",
+                "filters": {
+                    "year": "연도",
+                    "province": "지역",
+                    "category": "계열",
+                    "batch": "전형",
+                    "planType": "계획유형",
+                    "yourScore": "내 점수",
+                    "yourRanking": "내 순위",
+                    "query": "검색",
+                    "reset": "초기화",
+                    "dataSource": "데이터 출처"
+                },
+                "placeholder": {
+                    "year": "연도 선택",
+                    "province": "지역 선택",
+                    "category": "계열 선택 (선택사항)",
+                    "planType": "계획유형 선택 (선택사항)",
+                    "score": "점수 입력 (선택사항)",
+                    "ranking": "순위 입력 (선택사항)"
+                },
+                "dataSource": {
+                    "zsjy": "입학정보",
+                    "ranking": "길드 확장",
+                    "plan": "모집계획",
+                    "zsjyDescription": "장시 재경대학교 공식 입학정보 사이트의 공개 데이터로, 전공별 최고점과 최저점만 포함되어 있으며 순위 정보는 없습니다.",
+                    "rankingDescription": "사이버보안 길드가 지역별 순위 정보(최고점 순위 및 최저점 순위)를 보완했습니다. 순위 데이터는 참고용입니다.",
+                    "planDescription": "장시 재경대학교 공식 입학정보 사이트의 공개 데이터로, 각 지역별 전공 계획 모집 인원을 표시합니다."
+                },
+                "table": {
+                    "major": "전공명",
+                    "maxScore": "최고점",
+                    "minScore": "최저점",
+                    "maxRanking": "최고순위",
+                    "minRanking": "최저순위",
+                    "match": "적합",
+                    "category": "계열",
+                    "batch": "전형",
+                    "notes": "비고",
+                    "planCount": "모집인원",
+                    "planType": "계획유형",
+                    "majorCode": "전공코드"
+                },
+                "status": {
+                    "safe": "안정",
+                    "match": "적합",
+                    "reach": "도전가능",
+                    "far": "차이큼"
+                },
+                "sourceAlert": {
+                    "title": "데이터 출처 안내"
+                }
+            },
             "title": "개인정보 처리방침",
             "meta": {
                 "title": "개인정보 처리방침 - 장시 재경대학교 사이버보안 길드",

--- a/i18n/locales/zh.json
+++ b/i18n/locales/zh.json
@@ -18,7 +18,8 @@
             "members": "历届成员",
             "excellent": "优秀成员",
             "teacher": "社团指导老师"
-        }
+        },
+        "volunteer": "志愿查询"
     },
     "pages": {
         "timeline": {
@@ -86,6 +87,73 @@
                     "action": "操作",
                     "join": "参加"
                 }
+            }
+        },
+        "volunteer": {
+            "title": "志愿查询",
+            "meta": {
+                "title": "志愿查询 - 江西财经大学网络安全协会",
+                "description": "查询江西财经大学历年各省各专业的招生录取分数，为志愿填报提供参考。"
+            },
+            "loading": "正在加载数据...",
+            "error": "配置数据加载失败，请稍后重试",
+            "fetchError": "查询数据失败",
+            "empty": "未查询到相关数据",
+            "emptyHint": "该筛选条件下暂无录取数据，请尝试调整筛选条件",
+            "selectHint": "请选择年份和省份后点击查询",
+            "summary": "共 {count} 条记录",
+            "scoreHint": "你的分数：{score} 分",
+            "rankingHint": "你的位次：第 {ranking} 名",
+            "filters": {
+                "year": "年份",
+                "province": "省份",
+                "category": "科类",
+                "batch": "批次",
+                "planType": "计划类型",
+                "yourScore": "你的分数",
+                "yourRanking": "你的位次",
+                "query": "查询",
+                "reset": "重置",
+                "dataSource": "数据来源"
+            },
+            "placeholder": {
+                "year": "选择年份",
+                "province": "选择省份",
+                "category": "选择科类（可选）",
+                "planType": "选择计划类型（可选）",
+                "score": "输入分数（可选）",
+                "ranking": "输入位次（可选）"
+            },
+            "dataSource": {
+                "zsjy": "招生网",
+                "ranking": "协会补充",
+                "plan": "招生计划",
+                "zsjyDescription": "数据来自江西财经大学本科招生网公开数据，仅包含专业录取最高分与最低分，无排名信息。",
+                "rankingDescription": "数据由协会自行补齐了省排名信息（最高分位次与最低分位次），排名数据仅供参考。",
+                "planDescription": "数据来自江西财经大学本科招生网公开的招生计划数，展示各专业在各省的计划录取人数。"
+            },
+            "table": {
+                "major": "专业名称",
+                "maxScore": "最高分",
+                "minScore": "最低分",
+                "maxRanking": "最高分位次",
+                "minRanking": "最低分位次",
+                "match": "匹配",
+                "category": "科类",
+                "batch": "批次",
+                "notes": "备注",
+                "planCount": "计划数",
+                "planType": "计划类型",
+                "majorCode": "专业代码"
+            },
+            "status": {
+                "safe": "稳妥",
+                "match": "匹配",
+                "reach": "可冲",
+                "far": "差距较大"
+            },
+            "sourceAlert": {
+                "title": "数据来源说明"
             }
         },
         "privacy": {

--- a/pages/about/excellent.vue
+++ b/pages/about/excellent.vue
@@ -27,22 +27,14 @@
 <script setup lang="ts">
 import MemberHonorCard from "~/components/MemberHonorCard.vue";
 import { excellentData } from "~/data/excellentData";
-import { usePageTitle } from "@/composables/usePageTitle";
+
 const { t } = useI18n();
-const { setPageTitle } = usePageTitle();
-
-setPageTitle("pages.about.excellent.title");
-
-useHead(() => ({
-    title: t("pages.about.excellent.meta.title"),
-    meta: [
-        {
-            name: "description",
-            content: t("pages.about.excellent.meta.description"),
-        },
-        { name: "keywords", content: t("pages.about.excellent.meta.keywords") },
-    ],
-}));
+usePageMeta({
+    titleKey: "pages.about.excellent.title",
+    descriptionKey: "pages.about.excellent.meta.description",
+    keywords: t("pages.about.excellent.meta.keywords"),
+    canonicalPath: "/about/excellent",
+});
 </script>
 <style scoped>
 .grid-cols-auto-fill {

--- a/pages/about/index.vue
+++ b/pages/about/index.vue
@@ -6,16 +6,12 @@ import { teacherData } from "~/data/teacherData";
 import { honorsData, getLevelColor, getYearColor } from "~/data/honors";
 import { membersArray } from "~/data/membersData";
 import TeacherCard from "~/components/TeacherCard.vue";
-import { usePageTitle } from "@/composables/usePageTitle";
+
 
 const isMounted = ref(false);
 const currentQuote = ref(0);
 let quoteTimer: ReturnType<typeof setInterval> | null = null;
 const { t } = useI18n();
-const { setPageTitle } = usePageTitle();
-
-setPageTitle("pages.about.index.title");
-
 const quotes = [
     "太好听了吧！你打网安真的好好听啊，简直就是天籁！我刚才，听到你打网安了。我们以后一起打网安好不好？一起做学园偶像！",
     "放弃的话就到此为止了，但是，你可以改变命运()",
@@ -23,15 +19,12 @@ const quotes = [
     "协会可能会倒闭，但一定不会变质！（笑",
 ];
 
-useHead(() => ({
-    meta: [
-        {
-            name: "description",
-            content: t("pages.about.index.meta.description"),
-        },
-        { name: "keywords", content: t("pages.about.index.meta.keywords") },
-    ],
-}));
+usePageMeta({
+    titleKey: "pages.about.index.title",
+    descriptionKey: "pages.about.index.meta.description",
+    keywords: t("pages.about.index.meta.keywords"),
+    canonicalPath: "/about",
+});
 
 onMounted(() => {
     isMounted.value = true;

--- a/pages/about/leaders.vue
+++ b/pages/about/leaders.vue
@@ -21,19 +21,12 @@
 import LeadersList from "~/components/LeadersList.vue";
 import { leadersData } from "~/data/leadersData";
 import AnzuAlert from "~/components/AnzuAlert.vue";
-import { usePageTitle } from "@/composables/usePageTitle";
+
 const { t } = useI18n();
-const { setPageTitle } = usePageTitle();
-
-setPageTitle("pages.about.leaders.title");
-
-useHead(() => ({
-    meta: [
-        {
-            name: "description",
-            content: t("pages.about.leaders.meta.description"),
-        },
-        { name: "keywords", content: t("pages.about.leaders.meta.keywords") },
-    ],
-}));
+usePageMeta({
+    titleKey: "pages.about.leaders.title",
+    descriptionKey: "pages.about.leaders.meta.description",
+    keywords: t("pages.about.leaders.meta.keywords"),
+    canonicalPath: "/about/leaders",
+});
 </script>

--- a/pages/about/members/[year]/[memberindex].vue
+++ b/pages/about/members/[year]/[memberindex].vue
@@ -194,7 +194,14 @@ definePageMeta({
 
 const route = useRoute();
 const router = useRouter();
-const { t } = useI18n(); // Standard
+const { t } = useI18n();
+
+usePageMeta({
+    titleKey: "pages.about.members.title",
+    descriptionKey: "pages.about.members.meta.description",
+    keywords: t("pages.about.members.meta.keywords"),
+});
+
 const direction = ref(1);
 
 // --- Data Logic ---

--- a/pages/about/members/index.vue
+++ b/pages/about/members/index.vue
@@ -38,23 +38,15 @@
 
 <script setup lang="ts">
 import { membersArray } from "~/data/membersData";
-import { usePageTitle } from "@/composables/usePageTitle";
+
 const members = ref(membersArray);
 const { t } = useI18n();
-const { setPageTitle } = usePageTitle();
-
-setPageTitle("pages.about.members.title");
-
-useHead(() => ({
-    title: t("pages.about.members.meta.title"),
-    meta: [
-        {
-            name: "description",
-            content: t("pages.about.members.meta.description"),
-        },
-        { name: "keywords", content: t("pages.about.members.meta.keywords") },
-    ],
-}));
+usePageMeta({
+    titleKey: "pages.about.members.title",
+    descriptionKey: "pages.about.members.meta.description",
+    keywords: t("pages.about.members.meta.keywords"),
+    canonicalPath: "/about/members",
+});
 </script>
 
 <style scoped>

--- a/pages/about/teacher.vue
+++ b/pages/about/teacher.vue
@@ -13,20 +13,12 @@
 <script setup lang="ts">
 import TeacherCard from "~/components/TeacherCard.vue";
 import { teacherData } from "~/data/teacherData";
-import { usePageTitle } from "@/composables/usePageTitle";
+
 const { t } = useI18n();
-const { setPageTitle } = usePageTitle();
-
-setPageTitle("pages.about.teacher.title");
-
-useHead(() => ({
-    title: t("pages.about.teacher.meta.title"),
-    meta: [
-        {
-            name: "description",
-            content: t("pages.about.teacher.meta.description"),
-        },
-        { name: "keywords", content: t("pages.about.teacher.meta.keywords") },
-    ],
-}));
+usePageMeta({
+    titleKey: "pages.about.teacher.title",
+    descriptionKey: "pages.about.teacher.meta.description",
+    keywords: t("pages.about.teacher.meta.keywords"),
+    canonicalPath: "/about/teacher",
+});
 </script>

--- a/pages/archive/index.vue
+++ b/pages/archive/index.vue
@@ -59,18 +59,15 @@ import { ref, watch } from "vue";
 import { useRoute, useRouter } from "#imports";
 import { useApi } from "~/composables/useapi";
 import type { Archive } from "~/types/archives";
-import { usePageTitle } from "@/composables/usePageTitle";
+
 const { t } = useI18n();
-const { setPageTitle } = usePageTitle();
-
-setPageTitle("pages.archive.title", "", "nav.archive");
-
-useHead(() => ({
-    meta: [
-        { name: "description", content: t("pages.archive.meta.description") },
-        { name: "keywords", content: t("pages.archive.meta.keywords") },
-    ],
-}));
+usePageMeta({
+    titleKey: "pages.archive.title",
+    descriptionKey: "pages.archive.meta.description",
+    suffixKey: "nav.archive",
+    keywords: t("pages.archive.meta.keywords"),
+    canonicalPath: "/archive",
+});
 
 const route = useRoute();
 const router = useRouter();

--- a/pages/ctf-event.vue
+++ b/pages/ctf-event.vue
@@ -792,7 +792,7 @@ import AnzuButton from "@/components/AnzuButton.vue";
 import AnzuButtonGroup from "@/components/AnzuButtonGroup.vue";
 import AnzuPagination from "@/components/AnzuPagination.vue";
 import AnzuProgressRing from "@/components/AnzuProgressRing.vue";
-import { usePageTitle } from "@/composables/usePageTitle";
+
 
 definePageMeta({
     alias: "/ctf",
@@ -872,7 +872,6 @@ const DOMESTIC_SOURCE_URL =
 const route = useRoute();
 const router = useRouter();
 const { locale, t } = useI18n();
-const { setPageTitle } = usePageTitle();
 const events = ref<RawCTFEvent[]>([]);
 const loading = ref(false);
 const error = ref<string | null>(null);
@@ -883,10 +882,11 @@ const monthCursor = ref(
     new Date(new Date().getFullYear(), new Date().getMonth(), 1),
 );
 
-setPageTitle("pages.ctf.title");
-useHead(() => ({
-    meta: [{ name: "description", content: t("pages.ctf.meta.description") }],
-}));
+usePageMeta({
+    titleKey: "pages.ctf.title",
+    descriptionKey: "pages.ctf.meta.description",
+    canonicalPath: "/ctf-event",
+});
 
 const displayLocale = computed(() =>
     locale.value.toLowerCase().startsWith("en")

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -126,9 +126,12 @@ import type { Archive } from "~/types/archives";
 
 const { t } = useI18n();
 
-useHead(() => ({
-    meta: [{ name: "description", content: t("pages.home.meta.description") }],
-}));
+usePageMeta({
+    descriptionKey: "pages.home.meta.description",
+    keywords:
+        "江西财经大学,江财网安协会,网络安全,CTF,信息安全,江财,江西财经大学网络安全协会",
+    canonicalPath: "/",
+});
 
 const { data: archives, loading, error, get } = useApi<Archive[]>();
 const loadArticles = async () => {

--- a/pages/links.vue
+++ b/pages/links.vue
@@ -68,20 +68,16 @@
 <script lang="ts" setup>
 import { useLinks } from "~/data/eLinks";
 import { useI18n } from "vue-i18n";
-import { usePageTitle } from "@/composables/usePageTitle";
+
 
 const { Links, iLinks, fLinks } = useLinks();
 const { t } = useI18n();
-const { setPageTitle } = usePageTitle();
-
-setPageTitle("pages.links.title");
-
-useHead(() => ({
-    meta: [
-        { name: "description", content: t("pages.links.meta.description") },
-        { name: "keywords", content: t("pages.links.meta.keywords") },
-    ],
-}));
+usePageMeta({
+    titleKey: "pages.links.title",
+    descriptionKey: "pages.links.meta.description",
+    keywords: t("pages.links.meta.keywords"),
+    canonicalPath: "/links",
+});
 </script>
 
 <style scoped></style>

--- a/pages/privacy.vue
+++ b/pages/privacy.vue
@@ -1,19 +1,12 @@
 <script setup lang="ts">
-import { usePageTitle } from "@/composables/usePageTitle";
+
 
 const { t } = useI18n();
-const { setPageTitle } = usePageTitle();
-
-setPageTitle("pages.privacy.title");
-
-useHead(() => ({
-    meta: [
-        {
-            name: "description",
-            content: t("pages.privacy.meta.description"),
-        },
-    ],
-}));
+usePageMeta({
+    titleKey: "pages.privacy.title",
+    descriptionKey: "pages.privacy.meta.description",
+    canonicalPath: "/privacy",
+});
 
 const contactEmail = "1834488130@qq.com";
 

--- a/pages/timeline.vue
+++ b/pages/timeline.vue
@@ -58,11 +58,10 @@
 
 <script lang="ts" setup>
 import { timelineData } from "~/data/timelineData";
-import { usePageTitle } from "@/composables/usePageTitle";
+
 import { useI18n } from "vue-i18n";
 
 const { t } = useI18n();
-const { setPageTitle } = usePageTitle();
 const route = useRoute();
 
 const itemsPerPage = 10;
@@ -81,14 +80,11 @@ const paginatedData = computed(() => {
     return timelineData.slice(start, end);
 });
 
-setPageTitle("pages.timeline.title");
-
-useHead(() => ({
-    title: t("pages.timeline.meta.title"),
-    meta: [
-        { name: "description", content: t("pages.timeline.meta.description") },
-    ],
-}));
+usePageMeta({
+    titleKey: "pages.timeline.title",
+    descriptionKey: "pages.timeline.meta.description",
+    canonicalPath: "/timeline",
+});
 </script>
 
 <style scoped>

--- a/pages/volunteer.vue
+++ b/pages/volunteer.vue
@@ -1,0 +1,1263 @@
+<template>
+    <main
+        class="box-border bg-(--md-sys-color-surface-container-lowest) px-4 py-6 sm:px-6 sm:py-8"
+    >
+        <div class="mx-auto max-w-5xl space-y-6">
+            <div
+                v-if="configLoading"
+                class="flex min-h-72 flex-col items-center justify-center gap-4 text-center text-(--md-sys-color-on-surface-variant)"
+            >
+                <AnzuProgressRing :size="56" status="loading" />
+                <p class="text-sm sm:text-base">
+                    {{ t("pages.volunteer.loading") }}
+                </p>
+            </div>
+
+            <div
+                v-else-if="configError"
+                class="space-y-4 rounded-xl bg-(--md-sys-color-error-container)/60 p-5 text-(--md-sys-color-on-error-container)"
+            >
+                <div class="flex items-start gap-3">
+                    <ExclamationTriangleIcon class="mt-0.5 h-5 w-5 shrink-0" />
+                    <div class="space-y-2">
+                        <p class="font-semibold">
+                            {{ t("pages.volunteer.error") }}
+                        </p>
+                        <p class="text-sm opacity-80">{{ configError }}</p>
+                    </div>
+                </div>
+                <AnzuButton
+                    variant="filled"
+                    class="h-9! min-w-0! px-4!"
+                    @click="fetchConfig"
+                >
+                    {{ t("common.actions.reload") }}
+                </AnzuButton>
+            </div>
+
+            <section v-else class="space-y-5">
+                <div
+                    class="grid grid-cols-2 items-end gap-3 sm:flex sm:flex-wrap"
+                >
+                    <div class="flex flex-col gap-1">
+                        <label
+                            class="text-xs font-medium text-(--md-sys-color-on-surface-variant)"
+                        >
+                            {{ t("pages.volunteer.filters.year") }}
+                        </label>
+                        <AnzuComboBox
+                            v-model="selectedYear"
+                            :items="availableYears"
+                            :placeholder="t('pages.volunteer.placeholder.year')"
+                            :search-placeholder="
+                                t('pages.volunteer.placeholder.year')
+                            "
+                            :empty-text="t('common.items.empty')"
+                            menu-width-class="w-36"
+                            @change="onYearChange"
+                        />
+                    </div>
+
+                    <div class="flex flex-col gap-1">
+                        <label
+                            class="text-xs font-medium text-(--md-sys-color-on-surface-variant)"
+                        >
+                            {{ t("pages.volunteer.filters.province") }}
+                        </label>
+                        <AnzuComboBox
+                            v-model="selectedProvince"
+                            :items="availableProvinces"
+                            :placeholder="
+                                t('pages.volunteer.placeholder.province')
+                            "
+                            :search-placeholder="
+                                t('pages.volunteer.placeholder.province')
+                            "
+                            :empty-text="t('common.items.empty')"
+                            menu-width-class="w-44"
+                            @change="onProvinceChange"
+                        />
+                    </div>
+
+                    <div class="flex flex-col gap-1">
+                        <label
+                            class="text-xs font-medium text-(--md-sys-color-on-surface-variant)"
+                        >
+                            {{
+                                dataSource === "plan"
+                                    ? t("pages.volunteer.filters.planType")
+                                    : t("pages.volunteer.filters.category")
+                            }}
+                        </label>
+                        <AnzuComboBox
+                            v-if="dataSource === 'plan'"
+                            v-model="selectedPlanType"
+                            :items="availablePlanTypes"
+                            :placeholder="
+                                t('pages.volunteer.placeholder.planType')
+                            "
+                            :search-placeholder="
+                                t('pages.volunteer.placeholder.planType')
+                            "
+                            :empty-text="t('common.items.empty')"
+                            menu-width-class="w-44"
+                        />
+                        <AnzuComboBox
+                            v-else
+                            v-model="selectedCategory"
+                            :items="availableCategories"
+                            :placeholder="
+                                t('pages.volunteer.placeholder.category')
+                            "
+                            :search-placeholder="
+                                t('pages.volunteer.placeholder.category')
+                            "
+                            :empty-text="t('common.items.empty')"
+                            menu-width-class="w-44"
+                        />
+                    </div>
+
+                    <div class="col-span-2 flex gap-3 sm:contents">
+                        <AnzuButton
+                            variant="filled"
+                            class="h-10! flex-1 sm:min-w-0! sm:flex-initial sm:px-6!"
+                            :disabled="!canQuery || dataLoading"
+                            @click="queryData"
+                        >
+                            <MagnifyingGlassIcon
+                                v-if="!dataLoading"
+                                class="mr-1.5 h-4 w-4"
+                            />
+                            <AnzuProgressRing
+                                v-else
+                                :size="16"
+                                status="loading"
+                                class="mr-1.5"
+                            />
+                            {{ t("pages.volunteer.filters.query") }}
+                        </AnzuButton>
+
+                        <AnzuButton
+                            variant="outlined"
+                            class="h-10! flex-1 sm:min-w-0! sm:flex-initial sm:px-4!"
+                            @click="resetFilters"
+                        >
+                            {{ t("pages.volunteer.filters.reset") }}
+                        </AnzuButton>
+                    </div>
+                </div>
+                <div
+                    v-if="dataSource !== 'plan'"
+                    class="grid grid-cols-2 items-end gap-3 sm:flex sm:flex-wrap"
+                >
+                    <div class="flex flex-col gap-1">
+                        <label
+                            class="text-xs font-medium text-(--md-sys-color-on-surface-variant)"
+                        >
+                            {{ t("pages.volunteer.filters.yourScore") }}
+                        </label>
+                        <input
+                            v-model.number="userScore"
+                            type="number"
+                            :placeholder="
+                                t('pages.volunteer.placeholder.score')
+                            "
+                            class="h-10 w-full sm:w-28 rounded-md border border-(--md-sys-color-outline-variant) bg-(--md-sys-color-surface) px-3 text-sm text-(--md-sys-color-on-surface) outline-none transition-colors focus:ring-2 focus:ring-(--md-sys-color-primary)/20"
+                        />
+                    </div>
+
+                    <div
+                        v-if="dataSource === 'ranking'"
+                        class="flex flex-col gap-1"
+                    >
+                        <label
+                            class="text-xs font-medium text-(--md-sys-color-on-surface-variant)"
+                        >
+                            {{ t("pages.volunteer.filters.yourRanking") }}
+                        </label>
+                        <input
+                            v-model.number="userRanking"
+                            type="number"
+                            :placeholder="
+                                t('pages.volunteer.placeholder.ranking')
+                            "
+                            class="h-10 w-full sm:w-32 rounded-md border border-(--md-sys-color-outline-variant) bg-(--md-sys-color-surface) px-3 text-sm text-(--md-sys-color-on-surface) outline-none transition-colors focus:ring-2 focus:ring-(--md-sys-color-primary)/20"
+                        />
+                    </div>
+                </div>
+
+                <div class="flex flex-col gap-2">
+                    <label
+                        class="text-xs font-medium text-(--md-sys-color-on-surface-variant)"
+                    >
+                        {{ t("pages.volunteer.filters.dataSource") }}
+                    </label>
+                    <div class="flex gap-1">
+                        <button
+                            v-for="src in dataSources"
+                            :key="src.value"
+                            type="button"
+                            class="rounded-md px-3 py-1.5 text-xs font-medium transition-colors"
+                            :class="
+                                dataSource === src.value
+                                    ? 'bg-(--md-sys-color-primary) text-(--md-sys-color-on-primary)'
+                                    : 'bg-(--md-sys-color-surface-container) text-(--md-sys-color-on-surface-variant) hover:bg-(--md-sys-color-surface-container-high)'
+                            "
+                            @click="switchDataSource(src.value)"
+                        >
+                            {{ src.label }}
+                        </button>
+                    </div>
+                </div>
+
+                <AnzuAlert
+                    type="info"
+                    :title="t('pages.volunteer.sourceAlert.title')"
+                >
+                    <p class="text-sm whitespace-pre-line">
+                        {{ currentSourceDescription }}
+                    </p>
+                </AnzuAlert>
+
+                <div
+                    v-if="!hasQueried"
+                    class="flex min-h-48 flex-col items-center justify-center gap-2 py-12 text-center"
+                >
+                    <MagnifyingGlassIcon
+                        class="h-10 w-10 text-(--md-sys-color-on-surface-variant) opacity-40"
+                    />
+                    <p class="text-sm text-(--md-sys-color-on-surface-variant)">
+                        {{ t("pages.volunteer.selectHint") }}
+                    </p>
+                </div>
+
+                <div
+                    v-else-if="dataLoading"
+                    class="flex min-h-48 flex-col items-center justify-center gap-4 text-center text-(--md-sys-color-on-surface-variant)"
+                >
+                    <AnzuProgressRing :size="48" status="loading" />
+                    <p class="text-sm">
+                        {{ t("pages.volunteer.loading") }}
+                    </p>
+                </div>
+
+                <div
+                    v-else-if="dataError"
+                    class="space-y-4 rounded-xl bg-(--md-sys-color-error-container)/60 p-5 text-(--md-sys-color-on-error-container)"
+                >
+                    <div class="flex items-start gap-3">
+                        <ExclamationTriangleIcon
+                            class="mt-0.5 h-5 w-5 shrink-0"
+                        />
+                        <div class="space-y-2">
+                            <p class="font-semibold">
+                                {{ t("pages.volunteer.fetchError") }}
+                            </p>
+                            <p class="text-sm opacity-80">{{ dataError }}</p>
+                        </div>
+                    </div>
+                    <AnzuButton
+                        variant="filled"
+                        class="h-9! min-w-0! px-4!"
+                        @click="queryData"
+                    >
+                        {{ t("common.actions.reload") }}
+                    </AnzuButton>
+                </div>
+
+                <div v-else-if="results.length === 0" class="space-y-4">
+                    <div
+                        class="flex min-h-48 flex-col items-center justify-center gap-2 rounded-xl bg-(--md-sys-color-surface-container) py-12 text-center"
+                    >
+                        <p
+                            class="text-base font-medium text-(--md-sys-color-on-surface)"
+                        >
+                            {{ t("pages.volunteer.empty") }}
+                        </p>
+                        <p
+                            class="text-sm text-(--md-sys-color-on-surface-variant)"
+                        >
+                            {{ t("pages.volunteer.emptyHint") }}
+                        </p>
+                    </div>
+                </div>
+
+                <div v-else class="space-y-4">
+                    <div
+                        class="flex flex-wrap items-center gap-4 text-sm text-(--md-sys-color-on-surface-variant)"
+                    >
+                        <span>{{ summaryText }}</span>
+                        <span
+                            v-if="userScore"
+                            class="font-medium text-(--md-sys-color-primary)"
+                        >
+                            {{
+                                t("pages.volunteer.scoreHint", {
+                                    score: userScore,
+                                })
+                            }}
+                        </span>
+                        <span
+                            v-if="userRanking && dataSource === 'ranking'"
+                            class="font-medium text-(--md-sys-color-primary)"
+                        >
+                            {{
+                                t("pages.volunteer.rankingHint", {
+                                    ranking: userRanking,
+                                })
+                            }}
+                        </span>
+                    </div>
+                    <div
+                        v-if="dataSource !== 'plan'"
+                        class="hidden overflow-x-auto lg:block"
+                    >
+                        <table class="min-w-full table-fixed border-collapse">
+                            <thead>
+                                <tr
+                                    class="border-b border-(--md-sys-color-outline-variant)/60 text-left"
+                                >
+                                    <th
+                                        class="px-3 py-2 text-[11px] font-medium tracking-[0.14em] whitespace-nowrap text-(--md-sys-color-on-surface-variant)"
+                                        :class="
+                                            dataSource === 'ranking'
+                                                ? 'w-[22%]'
+                                                : showMatchCol
+                                                  ? 'w-[26%]'
+                                                  : 'w-[30%]'
+                                        "
+                                    >
+                                        {{ t("pages.volunteer.table.major") }}
+                                    </th>
+                                    <th
+                                        class="cursor-pointer select-none px-3 py-2 text-[11px] font-medium tracking-[0.14em] whitespace-nowrap transition-colors hover:text-(--md-sys-color-primary)"
+                                        :class="[
+                                            sortKey === 'maxScore'
+                                                ? 'text-(--md-sys-color-primary)'
+                                                : 'text-(--md-sys-color-on-surface-variant)',
+                                            dataSource === 'ranking'
+                                                ? 'w-[8%]'
+                                                : 'w-[10%]',
+                                        ]"
+                                        @click="toggleSort('maxScore')"
+                                    >
+                                        {{
+                                            t("pages.volunteer.table.maxScore")
+                                        }}
+                                        <span
+                                            v-if="sortKey === 'maxScore'"
+                                            class="ml-0.5"
+                                            >{{
+                                                sortDir === "desc" ? "↓" : "↑"
+                                            }}</span
+                                        >
+                                    </th>
+                                    <th
+                                        class="cursor-pointer select-none px-3 py-2 text-[11px] font-medium tracking-[0.14em] whitespace-nowrap transition-colors hover:text-(--md-sys-color-primary)"
+                                        :class="[
+                                            sortKey === 'minScore'
+                                                ? 'text-(--md-sys-color-primary)'
+                                                : 'text-(--md-sys-color-on-surface-variant)',
+                                            dataSource === 'ranking'
+                                                ? 'w-[8%]'
+                                                : 'w-[10%]',
+                                        ]"
+                                        @click="toggleSort('minScore')"
+                                    >
+                                        {{
+                                            t("pages.volunteer.table.minScore")
+                                        }}
+                                        <span
+                                            v-if="sortKey === 'minScore'"
+                                            class="ml-0.5"
+                                            >{{
+                                                sortDir === "desc" ? "↓" : "↑"
+                                            }}</span
+                                        >
+                                    </th>
+                                    <th
+                                        v-if="dataSource === 'ranking'"
+                                        class="w-[8%] px-3 py-2 text-[11px] font-medium tracking-[0.14em] whitespace-nowrap text-(--md-sys-color-on-surface-variant)"
+                                    >
+                                        {{
+                                            t(
+                                                "pages.volunteer.table.maxRanking",
+                                            )
+                                        }}
+                                    </th>
+                                    <th
+                                        v-if="dataSource === 'ranking'"
+                                        class="w-[8%] px-3 py-2 text-[11px] font-medium tracking-[0.14em] whitespace-nowrap text-(--md-sys-color-on-surface-variant)"
+                                    >
+                                        {{
+                                            t(
+                                                "pages.volunteer.table.minRanking",
+                                            )
+                                        }}
+                                    </th>
+                                    <th
+                                        v-if="showMatchCol"
+                                        class="px-3 py-2 text-[11px] font-medium tracking-[0.14em] whitespace-nowrap text-(--md-sys-color-on-surface-variant)"
+                                        :class="
+                                            dataSource === 'ranking'
+                                                ? 'w-[12%]'
+                                                : 'w-[14%]'
+                                        "
+                                    >
+                                        {{ t("pages.volunteer.table.match") }}
+                                    </th>
+                                    <th
+                                        class="w-[9%] px-3 py-2 text-[11px] font-medium tracking-[0.14em] whitespace-nowrap text-(--md-sys-color-on-surface-variant)"
+                                    >
+                                        {{
+                                            t("pages.volunteer.table.category")
+                                        }}
+                                    </th>
+                                    <th
+                                        class="w-[9%] px-3 py-2 text-[11px] font-medium tracking-[0.14em] whitespace-nowrap text-(--md-sys-color-on-surface-variant)"
+                                    >
+                                        {{ t("pages.volunteer.table.batch") }}
+                                    </th>
+                                    <th
+                                        class="px-3 py-2 text-[11px] font-medium tracking-[0.14em] whitespace-nowrap text-(--md-sys-color-on-surface-variant)"
+                                    >
+                                        {{ t("pages.volunteer.table.notes") }}
+                                    </th>
+                                </tr>
+                            </thead>
+                            <tbody
+                                class="divide-y divide-(--md-sys-color-outline-variant)/40"
+                            >
+                                <tr
+                                    v-for="(row, idx) in paginatedResults"
+                                    :key="row._id || idx"
+                                    class="transition-colors hover:bg-(--md-sys-color-surface-container)/45"
+                                >
+                                    <td
+                                        class="px-3 py-3 text-sm font-medium text-(--md-sys-color-on-surface)"
+                                    >
+                                        {{ row.E }}
+                                    </td>
+                                    <td
+                                        class="px-3 py-3 text-sm tabular-nums text-(--md-sys-color-on-surface)"
+                                    >
+                                        {{ row.F }}
+                                    </td>
+                                    <td
+                                        class="px-3 py-3 text-sm tabular-nums text-(--md-sys-color-on-surface)"
+                                    >
+                                        {{ row.G }}
+                                    </td>
+                                    <td
+                                        v-if="dataSource === 'ranking'"
+                                        class="px-3 py-3 text-sm tabular-nums text-(--md-sys-color-on-surface)"
+                                    >
+                                        {{ row.J }}
+                                    </td>
+                                    <td
+                                        v-if="dataSource === 'ranking'"
+                                        class="px-3 py-3 text-sm tabular-nums text-(--md-sys-color-on-surface)"
+                                    >
+                                        {{ row.I }}
+                                    </td>
+                                    <td v-if="showMatchCol" class="px-3 py-3">
+                                        <span
+                                            class="inline-flex shrink-0 items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium whitespace-nowrap"
+                                            :class="matchBadgeClass(row)"
+                                        >
+                                            {{ matchLabel(row) }}
+                                        </span>
+                                    </td>
+                                    <td
+                                        class="px-3 py-3 text-sm text-(--md-sys-color-on-surface-variant)"
+                                    >
+                                        {{ row.D }}
+                                    </td>
+                                    <td
+                                        class="px-3 py-3 text-sm text-(--md-sys-color-on-surface-variant)"
+                                    >
+                                        {{ row.C }}
+                                    </td>
+                                    <td
+                                        class="px-3 py-3 text-sm text-(--md-sys-color-on-surface-variant)"
+                                    >
+                                        {{ row.H }}
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <div v-else class="hidden overflow-x-auto lg:block">
+                        <table class="min-w-full table-fixed border-collapse">
+                            <thead>
+                                <tr
+                                    class="border-b border-(--md-sys-color-outline-variant)/60 text-left"
+                                >
+                                    <th
+                                        class="w-[30%] px-3 py-2 text-[11px] font-medium tracking-[0.14em] whitespace-nowrap text-(--md-sys-color-on-surface-variant)"
+                                    >
+                                        {{ t("pages.volunteer.table.major") }}
+                                    </th>
+                                    <th
+                                        class="w-[12%] px-3 py-2 text-[11px] font-medium tracking-[0.14em] whitespace-nowrap text-(--md-sys-color-on-surface-variant)"
+                                    >
+                                        {{
+                                            t("pages.volunteer.table.majorCode")
+                                        }}
+                                    </th>
+                                    <th
+                                        class="w-[22%] px-3 py-2 text-[11px] font-medium tracking-[0.14em] whitespace-nowrap text-(--md-sys-color-on-surface-variant)"
+                                    >
+                                        {{
+                                            t("pages.volunteer.table.planType")
+                                        }}
+                                    </th>
+                                    <th
+                                        class="w-[12%] px-3 py-2 text-[11px] font-medium tracking-[0.14em] whitespace-nowrap text-(--md-sys-color-on-surface-variant)"
+                                    >
+                                        {{
+                                            t("pages.volunteer.table.planCount")
+                                        }}
+                                    </th>
+                                    <th
+                                        class="px-3 py-2 text-[11px] font-medium tracking-[0.14em] whitespace-nowrap text-(--md-sys-color-on-surface-variant)"
+                                    >
+                                        {{ t("pages.volunteer.table.notes") }}
+                                    </th>
+                                </tr>
+                            </thead>
+                            <tbody
+                                class="divide-y divide-(--md-sys-color-outline-variant)/40"
+                            >
+                                <tr
+                                    v-for="(row, idx) in paginatedResults"
+                                    :key="row._id || idx"
+                                    class="transition-colors hover:bg-(--md-sys-color-surface-container)/45"
+                                >
+                                    <td
+                                        class="px-3 py-3 text-sm font-medium text-(--md-sys-color-on-surface)"
+                                    >
+                                        {{ row.C }}
+                                    </td>
+                                    <td
+                                        class="px-3 py-3 text-sm tabular-nums text-(--md-sys-color-on-surface-variant)"
+                                    >
+                                        {{ row.D }}
+                                    </td>
+                                    <td
+                                        class="px-3 py-3 text-sm text-(--md-sys-color-on-surface-variant)"
+                                    >
+                                        {{ row.F }}
+                                    </td>
+                                    <td
+                                        class="px-3 py-3 text-sm font-semibold tabular-nums text-(--md-sys-color-on-surface)"
+                                    >
+                                        {{ row.G }}
+                                    </td>
+                                    <td
+                                        class="px-3 py-3 text-sm text-(--md-sys-color-on-surface-variant)"
+                                    >
+                                        {{ row.E }}
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <div
+                        v-if="dataSource !== 'plan'"
+                        class="space-y-3 lg:hidden"
+                    >
+                        <article
+                            v-for="(row, idx) in paginatedResults"
+                            :key="row._id || `mobile-${idx}`"
+                            class="rounded-xl bg-(--md-sys-color-surface-container) p-4"
+                        >
+                            <div class="flex items-start justify-between gap-2">
+                                <div class="space-y-1">
+                                    <p
+                                        class="text-base font-semibold text-(--md-sys-color-on-surface)"
+                                    >
+                                        {{ row.E }}
+                                    </p>
+                                    <p
+                                        class="text-xs text-(--md-sys-color-on-surface-variant)"
+                                    >
+                                        {{ row.C }} · {{ row.D }}
+                                        <span v-if="row.H"> · {{ row.H }}</span>
+                                    </p>
+                                </div>
+                                <span
+                                    v-if="showMatchCol"
+                                    class="shrink-0 rounded-full px-2 py-0.5 text-xs font-medium"
+                                    :class="matchBadgeClass(row)"
+                                >
+                                    {{ matchLabel(row) }}
+                                </span>
+                            </div>
+                            <div
+                                class="mt-3 grid gap-x-3 gap-y-2 text-sm"
+                                :class="
+                                    dataSource === 'ranking'
+                                        ? 'grid-cols-2'
+                                        : 'grid-cols-2'
+                                "
+                            >
+                                <div>
+                                    <p
+                                        class="text-xs text-(--md-sys-color-on-surface-variant)"
+                                    >
+                                        {{
+                                            t("pages.volunteer.table.maxScore")
+                                        }}
+                                    </p>
+                                    <p
+                                        class="text-lg font-semibold tabular-nums text-(--md-sys-color-on-surface)"
+                                    >
+                                        {{ row.F }}
+                                    </p>
+                                </div>
+                                <div>
+                                    <p
+                                        class="text-xs text-(--md-sys-color-on-surface-variant)"
+                                    >
+                                        {{
+                                            t("pages.volunteer.table.minScore")
+                                        }}
+                                    </p>
+                                    <p
+                                        class="text-lg font-semibold tabular-nums text-(--md-sys-color-on-surface)"
+                                    >
+                                        {{ row.G }}
+                                    </p>
+                                </div>
+                                <template v-if="dataSource === 'ranking'">
+                                    <div>
+                                        <p
+                                            class="text-xs text-(--md-sys-color-on-surface-variant)"
+                                        >
+                                            {{
+                                                t(
+                                                    "pages.volunteer.table.maxRanking",
+                                                )
+                                            }}
+                                        </p>
+                                        <p
+                                            class="text-base font-semibold tabular-nums text-(--md-sys-color-on-surface)"
+                                        >
+                                            {{ row.J }}
+                                        </p>
+                                    </div>
+                                    <div>
+                                        <p
+                                            class="text-xs text-(--md-sys-color-on-surface-variant)"
+                                        >
+                                            {{
+                                                t(
+                                                    "pages.volunteer.table.minRanking",
+                                                )
+                                            }}
+                                        </p>
+                                        <p
+                                            class="text-base font-semibold tabular-nums text-(--md-sys-color-on-surface)"
+                                        >
+                                            {{ row.I }}
+                                        </p>
+                                    </div>
+                                </template>
+                            </div>
+                        </article>
+                    </div>
+                    <div v-else class="space-y-3 lg:hidden">
+                        <article
+                            v-for="(row, idx) in paginatedResults"
+                            :key="row._id || `mobile-plan-${idx}`"
+                            class="rounded-xl bg-(--md-sys-color-surface-container) p-4"
+                        >
+                            <div class="space-y-1">
+                                <p
+                                    class="text-base font-semibold text-(--md-sys-color-on-surface)"
+                                >
+                                    {{ row.C }}
+                                </p>
+                                <p
+                                    class="text-xs text-(--md-sys-color-on-surface-variant)"
+                                >
+                                    {{ row.F }}
+                                    <span v-if="row.D"> · {{ row.D }}</span>
+                                    <span v-if="row.E"> · {{ row.E }}</span>
+                                </p>
+                            </div>
+                            <div class="mt-3 flex items-end justify-between">
+                                <div>
+                                    <p
+                                        class="text-xs text-(--md-sys-color-on-surface-variant)"
+                                    >
+                                        {{
+                                            t("pages.volunteer.table.planCount")
+                                        }}
+                                    </p>
+                                    <p
+                                        class="text-2xl font-semibold tabular-nums text-(--md-sys-color-on-surface)"
+                                    >
+                                        {{ row.G }}
+                                    </p>
+                                </div>
+                            </div>
+                        </article>
+                    </div>
+
+                    <div class="flex justify-center">
+                        <AnzuPagination
+                            v-if="totalPages > 1"
+                            :total-pages="totalPages"
+                            :current-page="currentPage"
+                        />
+                    </div>
+                </div>
+            </section>
+        </div>
+    </main>
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick, onMounted, ref } from "vue";
+import { useRoute, useRouter } from "#imports";
+import { useI18n } from "vue-i18n";
+import {
+    MagnifyingGlassIcon,
+    ExclamationTriangleIcon,
+} from "@heroicons/vue/24/outline";
+import AnzuAlert from "@/components/AnzuAlert.vue";
+import AnzuButton from "@/components/AnzuButton.vue";
+import AnzuComboBox from "@/components/AnzuComboBox.vue";
+import AnzuPagination from "@/components/AnzuPagination.vue";
+import AnzuProgressRing from "@/components/AnzuProgressRing.vue";
+
+const PAGE_SIZE = 20;
+
+type DataSource = "zsjy" | "ranking" | "plan";
+type AllFilterItem = Record<string, string>;
+type EnrollRow = Record<string, string> & { _id?: string };
+type MatchStatus = "safe" | "match" | "reach" | "far";
+
+interface ConfigData {
+    detail: Record<string, unknown>;
+    filter: Record<string, string[]>;
+    all_filter: AllFilterItem[];
+}
+
+interface EnrollResponse {
+    code: number;
+    data: {
+        head: AllFilterItem[];
+        list: EnrollRow[];
+        total: number;
+    };
+    msg: string;
+}
+
+const route = useRoute();
+const router = useRouter();
+const { t } = useI18n();
+usePageMeta({
+    titleKey: "pages.volunteer.title",
+    descriptionKey: "pages.volunteer.meta.description",
+    keywords:
+        "江西财经大学录取分数,江财志愿填报,高考志愿查询,江财招生,江财录取位次,江西财经大学分数线",
+    canonicalPath: "/volunteer",
+    schema: {
+        "@type": "WebApplication",
+        applicationCategory: "EducationalApplication",
+        operatingSystem: "All",
+        offers: { "@type": "Offer", price: "0", priceCurrency: "CNY" },
+        author: {
+            "@type": "Organization",
+            name: t("meta.fullName"),
+            url: (useRuntimeConfig().public.siteUrl as string).replace(
+                /\/+$/,
+                "",
+            ),
+        },
+    },
+});
+
+const configLoading = ref(false);
+const configError = ref<string | null>(null);
+const filterOptions = ref<Record<string, string[]>>({});
+const allFilter = ref<AllFilterItem[]>([]);
+
+const planFilterOptions = ref<Record<string, string[]>>({});
+const planAllFilter = ref<AllFilterItem[]>([]);
+
+const selectedYear = ref<string | null>(null);
+const selectedProvince = ref<string | null>(null);
+const selectedCategory = ref<string | null>(null);
+const selectedPlanType = ref<string | null>(null);
+const userScore = ref<number | null>(null);
+const userRanking = ref<number | null>(null);
+
+const sortKey = ref<"maxScore" | "minScore" | null>(null);
+const sortDir = ref<"asc" | "desc">("desc");
+
+const dataLoading = ref(false);
+const dataError = ref<string | null>(null);
+const rawResults = ref<EnrollRow[]>([]);
+const hasQueried = ref(false);
+const dataSource = ref<DataSource>("zsjy");
+const rankingCache = ref<EnrollRow[] | null>(null);
+const rankingCacheLoading = ref(false);
+
+const dataSources = computed<{ label: string; value: DataSource }[]>(() => [
+    {
+        label: t("pages.volunteer.dataSource.zsjy"),
+        value: "zsjy",
+    },
+    {
+        label: t("pages.volunteer.dataSource.ranking"),
+        value: "ranking",
+    },
+    {
+        label: t("pages.volunteer.dataSource.plan"),
+        value: "plan",
+    },
+]);
+
+const currentSourceDescription = computed(() => {
+    if (dataSource.value === "ranking")
+        return t("pages.volunteer.dataSource.rankingDescription");
+    if (dataSource.value === "plan")
+        return t("pages.volunteer.dataSource.planDescription");
+    return t("pages.volunteer.dataSource.zsjyDescription");
+});
+
+const availablePlanTypes = computed(() => {
+    const base = planFilterOptions.value["F"] || [];
+    if (!selectedYear.value || !selectedProvince.value) return base;
+    const types = new Set<string>();
+    for (const f of planAllFilter.value) {
+        if (
+            f["A"] === selectedYear.value &&
+            f["B"] === selectedProvince.value &&
+            f["F"]
+        ) {
+            types.add(f["F"]);
+        }
+    }
+    return Array.from(types).sort();
+});
+
+const switchDataSource = async (src: DataSource) => {
+    if (src === dataSource.value) return;
+    dataSource.value = src;
+    rawResults.value = [];
+    hasQueried.value = false;
+    dataError.value = null;
+    sortKey.value = null;
+    selectedCategory.value = null;
+    selectedPlanType.value = null;
+    await nextTick();
+    selectedYear.value = "2025";
+    selectedProvince.value = src === "plan" ? "江西" : "江西省";
+};
+
+const parseScore = (row: EnrollRow, key: string): number => {
+    const v = parseInt(row[key] || "", 10);
+    return Number.isFinite(v) ? v : 0;
+};
+
+const getMatchStatus = (row: EnrollRow): MatchStatus => {
+    if (userRanking.value && dataSource.value === "ranking") {
+        const bestRank = Math.min(parseScore(row, "I"), parseScore(row, "J"));
+        const worstRank = Math.max(parseScore(row, "I"), parseScore(row, "J"));
+        if (worstRank === 0) return "far";
+        const r = userRanking.value;
+        if (r <= bestRank) return "safe";
+        if (r <= worstRank) return "match";
+        if (r <= Math.round(worstRank * 1.05)) return "reach";
+        return "far";
+    }
+    if (!userScore.value) return "far";
+    const s = userScore.value;
+    const minS = parseScore(row, "G");
+    const maxS = parseScore(row, "F");
+    if (s >= maxS) return "safe";
+    if (s >= minS) return "match";
+    if (s >= minS - 5) return "reach";
+    return "far";
+};
+
+const results = computed(() => {
+    const rows = [...rawResults.value];
+    if (sortKey.value) {
+        const key = sortKey.value === "maxScore" ? "F" : "G";
+        const dir = sortDir.value === "desc" ? -1 : 1;
+        rows.sort((a, b) => (parseScore(a, key) - parseScore(b, key)) * dir);
+    } else if (userRanking.value || userScore.value) {
+        rows.sort((a, b) => {
+            const aStatus = getMatchStatus(a);
+            const bStatus = getMatchStatus(b);
+            const order: Record<MatchStatus, number> = {
+                match: 0,
+                reach: 1,
+                safe: 2,
+                far: 3,
+            };
+            const oa = order[aStatus];
+            const ob = order[bStatus];
+            if (oa !== ob) return oa - ob;
+            if (userRanking.value && dataSource.value === "ranking") {
+                const aWorst = Math.max(parseScore(a, "I"), parseScore(a, "J"));
+                const bWorst = Math.max(parseScore(b, "I"), parseScore(b, "J"));
+                return (
+                    Math.abs(userRanking.value - aWorst) -
+                    Math.abs(userRanking.value - bWorst)
+                );
+            }
+            const aMin = parseScore(a, "G");
+            const bMin = parseScore(b, "G");
+            return (
+                Math.abs(userScore.value! - aMin) -
+                Math.abs(userScore.value! - bMin)
+            );
+        });
+    }
+    return rows;
+});
+
+const toggleSort = (key: "maxScore" | "minScore") => {
+    if (sortKey.value === key) {
+        if (sortDir.value === "desc") {
+            sortDir.value = "asc";
+        } else {
+            sortKey.value = null;
+        }
+    } else {
+        sortKey.value = key;
+        sortDir.value = "desc";
+    }
+};
+
+const currentFilterOptions = computed(() =>
+    dataSource.value === "plan" ? planFilterOptions.value : filterOptions.value,
+);
+
+const currentAllFilter = computed(() =>
+    dataSource.value === "plan" ? planAllFilter.value : allFilter.value,
+);
+
+const availableYears = computed(() =>
+    (currentFilterOptions.value["A"] || [])
+        .map((v) => v)
+        .sort()
+        .reverse(),
+);
+
+const availableProvinces = computed(() => {
+    if (!selectedYear.value) return currentFilterOptions.value["B"] || [];
+    const provinces = new Set<string>();
+    for (const f of currentAllFilter.value) {
+        if (f["A"] === selectedYear.value && f["B"]) {
+            provinces.add(f["B"]);
+        }
+    }
+    return Array.from(provinces).sort();
+});
+
+const availableCategories = computed(() => {
+    const base = currentFilterOptions.value["D"] || [];
+    if (!selectedYear.value || !selectedProvince.value) return base;
+    const cats = new Set<string>();
+    for (const f of currentAllFilter.value) {
+        if (
+            f["A"] === selectedYear.value &&
+            f["B"] === selectedProvince.value &&
+            f["D"]
+        ) {
+            cats.add(f["D"]);
+        }
+    }
+    return Array.from(cats).sort();
+});
+
+const canQuery = computed(() => selectedYear.value && selectedProvince.value);
+
+const showMatchCol = computed(
+    () =>
+        dataSource.value !== "plan" &&
+        !!(
+            userScore.value ||
+            (userRanking.value && dataSource.value === "ranking")
+        ),
+);
+
+const currentPage = computed(() => {
+    const raw = Array.isArray(route.query.page)
+        ? route.query.page[0]
+        : route.query.page;
+    const page = Number(raw || 1);
+    return !Number.isFinite(page) || page < 1
+        ? 1
+        : Math.min(page, totalPages.value);
+});
+
+const totalPages = computed(() =>
+    Math.max(1, Math.ceil(results.value.length / PAGE_SIZE)),
+);
+
+const paginatedResults = computed(() =>
+    results.value.slice(
+        (currentPage.value - 1) * PAGE_SIZE,
+        currentPage.value * PAGE_SIZE,
+    ),
+);
+
+const summaryText = computed(() =>
+    t("pages.volunteer.summary", { count: results.value.length }),
+);
+
+const matchBadgeClass = (row: EnrollRow) => {
+    const s = getMatchStatus(row);
+    switch (s) {
+        case "safe":
+            return "bg-(--md-sys-color-tertiary-container) text-(--md-sys-color-on-tertiary-container)";
+        case "match":
+            return "bg-(--md-sys-color-primary-container) text-(--md-sys-color-on-primary-container)";
+        case "reach":
+            return "bg-(--md-sys-color-secondary-container) text-(--md-sys-color-on-secondary-container)";
+        default:
+            return "";
+    }
+};
+
+const matchLabel = (row: EnrollRow): string => {
+    if (userRanking.value && dataSource.value === "ranking") {
+        const s = getMatchStatus(row);
+        const bestRank = Math.min(parseScore(row, "I"), parseScore(row, "J"));
+        const worstRank = Math.max(parseScore(row, "I"), parseScore(row, "J"));
+        const diffNum =
+            s === "safe"
+                ? bestRank - userRanking.value!
+                : worstRank - userRanking.value!;
+        const diffStr = diffNum > 0 ? `+${diffNum}` : `${diffNum}`;
+        return `${t(`pages.volunteer.status.${s}`)} ${diffStr}`;
+    }
+    if (!userScore.value) return "";
+    const s = getMatchStatus(row);
+    const minS = parseScore(row, "G");
+    const maxS = parseScore(row, "F");
+    const diffNum =
+        s === "safe" ? userScore.value! - maxS : userScore.value! - minS;
+    const diffStr = diffNum > 0 ? `+${diffNum}` : `${diffNum}`;
+    return `${t(`pages.volunteer.status.${s}`)} ${diffStr}`;
+};
+
+const fetchConfig = async () => {
+    configLoading.value = true;
+    configError.value = null;
+    try {
+        const [scoreResp, planResp] = await Promise.all([
+            $fetch<{
+                code: number;
+                data: ConfigData;
+                msg: string;
+            }>(
+                "https://job-web-api.jobpi.cn/enroll/config/v2/2658?sch_school_id=30285",
+            ),
+            $fetch<{
+                code: number;
+                data: ConfigData;
+                msg: string;
+            }>(
+                "https://job-web-api.jobpi.cn/enroll/config/v2/1974?sch_school_id=30285",
+            ),
+        ]);
+        if (scoreResp.code !== 200) {
+            throw new Error(scoreResp.msg || "Score config fetch failed");
+        }
+        if (planResp.code !== 200) {
+            throw new Error(planResp.msg || "Plan config fetch failed");
+        }
+        filterOptions.value = scoreResp.data.filter;
+        allFilter.value = scoreResp.data.all_filter;
+        planFilterOptions.value = planResp.data.filter;
+        planAllFilter.value = planResp.data.all_filter;
+        selectedYear.value = "2025";
+        selectedProvince.value = "江西省";
+    } catch (err) {
+        console.error(err);
+        configError.value =
+            (err as Error).message || t("pages.volunteer.fetchError");
+    } finally {
+        configLoading.value = false;
+    }
+};
+
+const queryData = async () => {
+    if (!canQuery.value) return;
+
+    const filterObj: Record<string, string> = {
+        A: selectedYear.value!,
+        B: selectedProvince.value!,
+    };
+    if (dataSource.value === "plan") {
+        if (selectedPlanType.value) {
+            filterObj["F"] = selectedPlanType.value;
+        }
+    } else {
+        if (selectedCategory.value) {
+            filterObj["D"] = selectedCategory.value;
+        }
+    }
+
+    dataLoading.value = true;
+    dataError.value = null;
+    rawResults.value = [];
+    sortKey.value = null;
+    hasQueried.value = true;
+
+    try {
+        let allRows: EnrollRow[] = [];
+
+        if (dataSource.value === "ranking") {
+            if (!rankingCache.value) {
+                rankingCacheLoading.value = true;
+                try {
+                    rankingCache.value = await $fetch<EnrollRow[]>(
+                        "https://csec.jxufe.edu.cn/nozomi/f/%E6%80%BB%E5%BD%95%E5%8F%96%E6%95%B0%E6%8D%AE",
+                    );
+                } finally {
+                    rankingCacheLoading.value = false;
+                }
+            }
+            allRows = (rankingCache.value || []).filter((row) => {
+                for (const [key, val] of Object.entries(filterObj)) {
+                    if (val && row[key] !== val) return false;
+                }
+                return true;
+            });
+        } else if (dataSource.value === "plan") {
+            let page = 1;
+            let total = 0;
+
+            while (true) {
+                const params = new URLSearchParams({
+                    sch_school_id: "30285",
+                    filter_column: JSON.stringify(filterObj),
+                    page: String(page),
+                    page_size: "100",
+                });
+                const resp = await $fetch<EnrollResponse>(
+                    `https://job-web-api.jobpi.cn/enroll/1974?${params}`,
+                );
+                if (resp.code !== 200) {
+                    throw new Error(resp.msg || "Data fetch failed");
+                }
+                allRows = allRows.concat(resp.data.list);
+                total = resp.data.total;
+                if (allRows.length >= total) break;
+                page += 1;
+            }
+        } else {
+            let page = 1;
+            let total = 0;
+
+            while (true) {
+                const params = new URLSearchParams({
+                    sch_school_id: "30285",
+                    filter_column: JSON.stringify(filterObj),
+                    page: String(page),
+                    page_size: "100",
+                });
+                const resp = await $fetch<EnrollResponse>(
+                    `https://job-web-api.jobpi.cn/enroll/2658?${params}`,
+                );
+                if (resp.code !== 200) {
+                    throw new Error(resp.msg || "Data fetch failed");
+                }
+                allRows = allRows.concat(resp.data.list);
+                total = resp.data.total;
+                if (allRows.length >= total) break;
+                page += 1;
+            }
+        }
+
+        rawResults.value = allRows;
+
+        const targetPage = Math.min(
+            currentPage.value,
+            Math.max(1, Math.ceil(allRows.length / PAGE_SIZE)),
+        );
+        if (targetPage !== currentPage.value) {
+            await router.push({
+                path: route.path,
+                query: { ...route.query, page: targetPage },
+            });
+        }
+    } catch (err) {
+        console.error(err);
+        dataError.value =
+            (err as Error).message || t("pages.volunteer.fetchError");
+    } finally {
+        dataLoading.value = false;
+    }
+};
+
+const resetFilters = () => {
+    selectedYear.value = "2025";
+    selectedProvince.value = "江西省";
+    selectedCategory.value = null;
+    selectedPlanType.value = null;
+    userScore.value = null;
+    userRanking.value = null;
+    sortKey.value = null;
+    rawResults.value = [];
+    hasQueried.value = false;
+    dataError.value = null;
+};
+
+const onYearChange = () => {
+    if (
+        selectedProvince.value &&
+        !availableProvinces.value.includes(selectedProvince.value)
+    ) {
+        selectedProvince.value = null;
+    }
+    if (dataSource.value === "plan") {
+        if (
+            selectedPlanType.value &&
+            !availablePlanTypes.value.includes(selectedPlanType.value)
+        ) {
+            selectedPlanType.value = null;
+        }
+    } else {
+        if (
+            selectedCategory.value &&
+            !availableCategories.value.includes(selectedCategory.value)
+        ) {
+            selectedCategory.value = null;
+        }
+    }
+};
+
+const onProvinceChange = () => {
+    if (dataSource.value === "plan") {
+        if (
+            selectedPlanType.value &&
+            !availablePlanTypes.value.includes(selectedPlanType.value)
+        ) {
+            selectedPlanType.value = null;
+        }
+    } else {
+        if (
+            selectedCategory.value &&
+            !availableCategories.value.includes(selectedCategory.value)
+        ) {
+            selectedCategory.value = null;
+        }
+    }
+};
+
+onMounted(() => {
+    fetchConfig();
+});
+</script>

--- a/pages/volunteer.vue
+++ b/pages/volunteer.vue
@@ -734,6 +734,7 @@ import AnzuPagination from "@/components/AnzuPagination.vue";
 import AnzuProgressRing from "@/components/AnzuProgressRing.vue";
 
 const PAGE_SIZE = 20;
+const MAX_PAGES = 20;
 
 type DataSource = "zsjy" | "ranking" | "plan";
 type AllFilterItem = Record<string, string>;
@@ -1139,7 +1140,7 @@ const queryData = async () => {
             let page = 1;
             let total = 0;
 
-            while (true) {
+            while (page <= MAX_PAGES) {
                 const params = new URLSearchParams({
                     sch_school_id: "30285",
                     filter_column: JSON.stringify(filterObj),
@@ -1154,14 +1155,14 @@ const queryData = async () => {
                 }
                 allRows = allRows.concat(resp.data.list);
                 total = resp.data.total;
-                if (allRows.length >= total) break;
+                if (allRows.length >= total || resp.data.list.length === 0) break;
                 page += 1;
             }
         } else {
             let page = 1;
             let total = 0;
 
-            while (true) {
+            while (page <= MAX_PAGES) {
                 const params = new URLSearchParams({
                     sch_school_id: "30285",
                     filter_column: JSON.stringify(filterObj),
@@ -1176,7 +1177,7 @@ const queryData = async () => {
                 }
                 allRows = allRows.concat(resp.data.list);
                 total = resp.data.total;
-                if (allRows.length >= total) break;
+                if (allRows.length >= total || resp.data.list.length === 0) break;
                 page += 1;
             }
         }
@@ -1204,7 +1205,8 @@ const queryData = async () => {
 
 const resetFilters = () => {
     selectedYear.value = "2025";
-    selectedProvince.value = "江西省";
+    selectedProvince.value =
+        dataSource.value === "plan" ? "江西" : "江西省";
     selectedCategory.value = null;
     selectedPlanType.value = null;
     userScore.value = null;

--- a/pages/wiki/index.vue
+++ b/pages/wiki/index.vue
@@ -50,7 +50,7 @@
 
 <script setup lang="ts">
 import { onMounted } from "vue";
-import { usePageTitle } from "@/composables/usePageTitle";
+
 import {
     BookOpenIcon,
     FolderIcon,
@@ -64,12 +64,8 @@ import type { WikiTreeNode } from "~/types/wiki";
 import AnzuProgressRing from "~/components/AnzuProgressRing.vue";
 import WikiIndexTreeItem from "~/components/WikiIndexTreeItem.vue";
 
-const { setPageTitle } = usePageTitle();
-
 const { t } = useI18n();
 const router = useRouter();
-
-setPageTitle("pages.wiki.title", "", "nav.wiki");
 
 const { data, get, loading, error } = useApi<WikiTreeNode>();
 
@@ -85,7 +81,10 @@ onMounted(() => {
     get("/v1/tree?root=wiki&depth=0");
 });
 
-useHead(() => ({
-    meta: [{ name: "description", content: t("pages.wiki.meta.description") }],
-}));
+usePageMeta({
+    titleKey: "pages.wiki.title",
+    descriptionKey: "pages.wiki.meta.description",
+    suffixKey: "nav.wiki",
+    canonicalPath: "/wiki",
+});
 </script>


### PR DESCRIPTION
**功能：志愿查询集成**
- 添加了志愿查询功能
- 在导航组合式函数（`useNavLinks.ts`）中为“志愿查询”（`/volunteer`）添加了新的导航链接，配有相应的图标和国际化标签。[[1]](diffhunk://#diff-484eac4333d23330e2d1a6ef16ecc92a9a2df6fd680dd80a038a23ea86035449R10) [[2]](diffhunk://#diff-484eac4333d23330e2d1a6ef16ecc92a9a2df6fd680dd80a038a23ea86035449R81-R86)

另注：**将在高考后将此导航路由取消自动放到“更多”中**

**SEO 与元数据管理**

- 引入了一个新的组合式函数 `usePageMeta`，用于集中并自动生成静态页面的 SEO 元数据，减少手动样板代码并确保一致性（`usePageMeta.ts`）。
- 更新了架构文档，以描述新的 SEO 管理方式，概述 `usePageMeta` 和 `useBotMeta` 的用法，并规定了标题和元数据组装的最佳实践（`docs/architecture.md`）。
