### PR TITLE
fix(markdown): 防止 GitHub 保留路径被错误识别为用户/仓库卡片

### DIFF
--- a/utils/markdown-it-github-card.ts
+++ b/utils/markdown-it-github-card.ts
@@ -12,6 +12,16 @@ interface ParsedGithubLink {
     tag?: string;
 }
 
+const RESERVED_PATHS = new Set([
+    "login", "logout", "signup", "settings", "notifications", "explore",
+    "marketplace", "sponsors", "codespaces", "organizations", "pricing",
+    "features", "new", "import", "search", "dashboard", "stars", "gists",
+    "discussions", "topics", "trending", "collections", "events", "about",
+    "blog", "contact", "security", "pull", "issues", "pulls", "releases",
+    "tags", "tree", "blob", "commit", "commits", "watchers", "stargazers",
+    "forks", "branches", "account", "copilot",
+]);
+
 const getLinkKey = (link: ParsedGithubLink): string => {
     return [
         link.type,
@@ -40,7 +50,7 @@ const parseGithubLink = (href: string): ParsedGithubLink | null => {
         .filter(Boolean);
 
     const owner = segments[0];
-    if (!owner) return null;
+    if (!owner || RESERVED_PATHS.has(owner.toLowerCase())) return null;
 
     if (segments.length === 1) {
         return {

--- a/utils/markdown-it-github-card.ts
+++ b/utils/markdown-it-github-card.ts
@@ -19,7 +19,7 @@ const RESERVED_PATHS = new Set([
     "discussions", "topics", "trending", "collections", "events", "about",
     "blog", "contact", "security", "pull", "issues", "pulls", "releases",
     "tags", "tree", "blob", "commit", "commits", "watchers", "stargazers",
-    "forks", "branches", "account", "copilot",
+    "forks", "branches", "account", "copilot", "orgs",
 ]);
 
 const getLinkKey = (link: ParsedGithubLink): string => {


### PR DESCRIPTION
更新了 GitHub 链接解析逻辑，通过过滤掉无效的用户或组织名称的保留路径来提高准确性。这可以防止解析器将某些 GitHub URL 错误地识别为用户或组织链接。

**链接解析的改进：**

* 添加了一个 `RESERVED_PATHS` 集合，用于定义常见的 GitHub 保留路由（如 `login`、`settings`、`pull` 等），并更新了 `parseGithubLink` 函数：如果 URL 的第一个路径段匹配任何保留路径，则返回 `null`，从而避免将用户/组织链接误判。 [[1]](diffhunk://#diff-17a220bee3444e5434b8867440e74510066f0a38c8b201379e642171dbc37ebbR15-R24) [[2]](diffhunk://#diff-17a220bee3444e5434b8867440e74510066f0a38c8b201379e642171dbc37ebbL43-R53)