### PR TITLE
fix(breadcrumb): 修复面包屑结构化数据中 item.id 为无效相对路径的问题

### DIFF
--- a/components/AnzuBreadcrumbs.vue
+++ b/components/AnzuBreadcrumbs.vue
@@ -108,11 +108,10 @@ const route = useRoute();
 const config = useRuntimeConfig();
 
 const getItemUrl = (item: BreadcrumbItem, index: number) => {
-    const base = config.public.siteUrl;
     if (index === props.items.length - 1) {
-        return base + route.fullPath;
+        return new URL(route.path, config.public.siteUrl).toString();
     }
-    return item.to ? base + item.to : base + route.fullPath;
+    return new URL(item.to || route.path, config.public.siteUrl).toString();
 };
 </script>
 

--- a/components/AnzuBreadcrumbs.vue
+++ b/components/AnzuBreadcrumbs.vue
@@ -44,6 +44,9 @@
                     class="hover:text-(--md-sys-color-on-surface) hover:bg-(--md-sys-color-on-surface-variant)/8 rounded-md px-2 py-1 -mx-2 transition-all duration-200 flex items-center gap-1.5 cursor-pointer font-medium"
                     @click.prevent="handleClick(item, index)"
                     itemprop="item"
+                    itemscope
+                    itemtype="https://schema.org/Thing"
+                    :itemid="getItemUrl(item, index)"
                 >
                     <component
                         v-if="item.icon"
@@ -61,6 +64,9 @@
                     "
                     @click="handleClick(item, index)"
                     itemprop="item"
+                    itemscope
+                    itemtype="https://schema.org/Thing"
+                    :itemid="getItemUrl(item, index)"
                 >
                     <component
                         v-if="item.icon"
@@ -94,9 +100,20 @@ export interface BreadcrumbItem {
     icon?: Component;
 }
 
-defineProps<{
+const props = defineProps<{
     items: BreadcrumbItem[];
 }>();
+
+const route = useRoute();
+const config = useRuntimeConfig();
+
+const getItemUrl = (item: BreadcrumbItem, index: number) => {
+    const base = config.public.siteUrl;
+    if (index === props.items.length - 1) {
+        return base + route.fullPath;
+    }
+    return item.to ? base + item.to : base + route.fullPath;
+};
 </script>
 
 <style scoped>


### PR DESCRIPTION
(AnzuBreadcrumbs.vue)为每个 `ListItem` 的 `item` 添加 `itemscope/itemtype/itemid`，将相对路径转为绝对 URL， 修复 Google Search Console 报告的"字段'id'中的网址无效"问题。